### PR TITLE
fix bug about file size adn

### DIFF
--- a/kv_options.cpp
+++ b/kv_options.cpp
@@ -194,6 +194,6 @@ size_t KvOptions::FilePageOffsetMask() const
 
 size_t KvOptions::DataFileSize() const
 {
-    return data_page_size << pages_per_file_shift;
+    return static_cast<size_t>(data_page_size) << pages_per_file_shift;
 }
 }  // namespace eloqstore

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(UTEST_SOURCES
     concurrency.cpp
     cloud.cpp
     gc.cpp
+    chore.cpp
     eloq_store_test.cpp
 )
 

--- a/tests/chore.cpp
+++ b/tests/chore.cpp
@@ -1,0 +1,163 @@
+#include <glog/logging.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+#include "common.h"
+#include "test_utils.h"
+
+using namespace eloqstore;
+using test_util::MapVerifier;
+TEST_CASE("file size tests - different page sizes", "[chore][file_size]")
+{
+    // Test different page sizes (must be power of 2 and aligned)
+    std::vector<uint16_t> page_sizes = {
+        1 << 12,  // 4KB
+        1 << 13,  // 8KB
+        1 << 14,  // 16KB
+        1 << 15,  // 32KB
+    };
+
+    for (uint16_t page_size : page_sizes)
+    {
+        KvOptions opts = default_opts;
+        opts.data_page_size = page_size;
+        opts.pages_per_file_shift = 10;  // 1024 pages per file
+        opts.data_append_mode = true;
+
+        EloqStore *store = InitStore(opts);
+
+        // Write some data to trigger file creation
+        MapVerifier tester(test_tbl_id, store, false);
+        tester.Upsert(0, 100);  // Write 100 entries
+
+        REQUIRE(ValidateFileSizes(opts));
+    }
+}
+
+TEST_CASE("file size tests - different file sizes", "[chore][file_size]")
+{
+    // Test different file sizes through pages_per_file_shift
+    std::vector<std::pair<uint8_t, std::string>> file_configs = {
+        {8, "1MB"},     // 2^8 = 256 pages * 4KB = 1MB
+        {10, "4MB"},    // 2^10 = 1024 pages * 4KB = 4MB
+        {12, "16MB"},   // 2^12 = 4096 pages * 4KB = 16MB
+        {14, "64MB"},   // 2^14 = 16384 pages * 4KB = 64MB
+        {16, "256MB"},  // 2^16 = 65536 pages * 4KB = 256MB
+        {18, "1GB"},    // 2^18 = 262144 pages * 4KB = 1GB
+    };
+
+    for (auto [shift, size_desc] : file_configs)
+    {
+        KvOptions opts = default_opts;
+        opts.data_page_size = 1 << 12;  // 4KB
+        opts.pages_per_file_shift = shift;
+        opts.data_append_mode = true;
+
+        EloqStore *store = InitStore(opts);
+
+        // Write data to trigger file creation
+        MapVerifier tester(test_tbl_id, store, false);
+        tester.Upsert(0, 50);  // Write 50 entries
+
+        // Log expected file size
+        size_t expected_file_size = opts.DataFileSize();
+
+        REQUIRE(ValidateFileSizes(opts));
+    }
+}
+
+TEST_CASE("file size tests - massive data injection", "[chore][file_size]")
+{
+    KvOptions opts = default_opts;
+    opts.data_page_size = 1 << 12;   // 4KB
+    opts.pages_per_file_shift = 16;  // 256MB files
+    opts.data_append_mode = true;
+    opts.manifest_limit = 16 << 20;  // 16MB manifest limit
+
+    EloqStore *store = InitStore(opts);
+
+    // Inject massive amount of data to test file size limits
+    MapVerifier tester(test_tbl_id, store, false);
+    tester.SetValueSize(1024);  // 1KB values
+
+    // Write data in batches to fill multiple files
+    const int batch_size = 1000;
+    const int num_batches = 10;
+
+    for (int batch = 0; batch < num_batches; batch++)
+    {
+        uint64_t start_key = batch * batch_size;
+        uint64_t end_key = start_key + batch_size;
+
+        tester.Upsert(start_key, end_key);
+
+        // Validate file sizes after each batch
+        if ((batch + 1) % 3 == 0)  // Check every 3 batches
+        {
+            REQUIRE(ValidateFileSizes(opts));
+        }
+    }
+
+    REQUIRE(ValidateFileSizes(opts));
+}
+
+TEST_CASE("file size tests - extreme page count per file", "[chore][file_size]")
+{
+    // Test with maximum reasonable pages_per_file_shift
+    std::vector<std::pair<uint8_t, std::string>> extreme_configs = {
+        {19, "2GB"}, {20, "4GB"}, {21, "8GB"}};
+
+    for (auto [shift, size_desc] : extreme_configs)
+    {
+        KvOptions opts = default_opts;
+        opts.data_page_size = 1 << 12;  // 4KB
+        opts.pages_per_file_shift = shift;
+        opts.data_append_mode = true;
+
+        EloqStore *store = InitStore(opts);
+
+        // Write minimal data just to create the file structure
+        MapVerifier tester(test_tbl_id, store, false);
+        tester.Upsert(0, 10);  // Write only 10 entries
+
+        // Log expected vs actual
+        size_t expected_file_size = opts.DataFileSize();
+
+        REQUIRE(ValidateFileSizes(opts));
+    }
+}
+
+TEST_CASE("file size tests - mixed page and file size combinations",
+          "[chore][file_size]")
+{
+    // Test various combinations of page size and file size
+    std::vector<std::tuple<uint16_t, uint8_t, std::string>> combinations = {
+        {1 << 12, 10, "4KB pages, 4MB files"},     // 4KB * 1024 = 4MB
+        {1 << 13, 11, "8KB pages, 16MB files"},    // 8KB * 2048 = 16MB
+        {1 << 14, 12, "16KB pages, 64MB files"},   // 16KB * 4096 = 64MB
+        {1 << 15, 13, "32KB pages, 256MB files"},  // 32KB * 8192 = 256MB
+    };
+
+    for (auto [page_size, shift, desc] : combinations)
+    {
+        KvOptions opts = default_opts;
+        opts.data_page_size = page_size;
+        opts.pages_per_file_shift = shift;
+        opts.data_append_mode = true;
+
+        EloqStore *store = InitStore(opts);
+
+        // Write data proportional to page size
+        MapVerifier tester(test_tbl_id, store, false);
+        tester.SetValueSize(page_size / 8);  // Value size = 1/8 of page size
+        tester.Upsert(0, 100);
+
+        // Log configuration
+        size_t expected_file_size = opts.DataFileSize();
+
+        // Validate
+        REQUIRE(ValidateFileSizes(opts));
+    }
+}

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -3,6 +3,8 @@
 #include <cassert>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
+#include <filesystem>
+#include <string>
 
 eloqstore::EloqStore *InitStore(const eloqstore::KvOptions &opts)
 {
@@ -18,4 +20,98 @@ eloqstore::EloqStore *InitStore(const eloqstore::KvOptions &opts)
     eloqstore::KvError err = eloq_store->Start();
     CHECK(err == eloqstore::KvError::NoError);
     return eloq_store.get();
+}
+
+bool ValidateFileSizes(const eloqstore::KvOptions &opts)
+{
+    bool all_valid = true;
+
+    size_t max_data_file_size = opts.DataFileSize();
+    size_t max_manifest_size = opts.manifest_limit;
+
+    LOG(INFO) << "Validating file sizes - Max data file: "
+              << (max_data_file_size / 1024 / 1024)
+              << " MB, Max manifest: " << (max_manifest_size / 1024 / 1024)
+              << " MB";
+
+    for (const std::string &store_path : opts.store_path)
+    {
+        if (!std::filesystem::exists(store_path))
+        {
+            LOG(WARNING) << "Store path does not exist: " << store_path;
+            continue;
+        }
+
+        try
+        {
+            for (const auto &entry :
+                 std::filesystem::recursive_directory_iterator(store_path))
+            {
+                if (!entry.is_regular_file())
+                {
+                    continue;
+                }
+
+                std::string filename = entry.path().filename().string();
+                size_t file_size = entry.file_size();
+
+                if (filename.find("data_") == 0)
+                {
+                    if (file_size > max_data_file_size)
+                    {
+                        LOG(ERROR)
+                            << "Data file exceeds size limit: " << entry.path()
+                            << " (size: " << (file_size / 1024 / 1024)
+                            << " MB, limit: "
+                            << (max_data_file_size / 1024 / 1024) << " MB)";
+                        all_valid = false;
+                    }
+                    else
+                    {
+                        LOG(INFO) << "✓ Data file size OK: " << filename << " ("
+                                  << (file_size / 1024 / 1024) << " MB)";
+                    }
+                }
+                else if (filename == "manifest")
+                {
+                    if (file_size > max_manifest_size)
+                    {
+                        LOG(ERROR)
+                            << "Manifest file exceeds size limit: "
+                            << entry.path() << " (size: " << (file_size / 1024)
+                            << " KB, limit: " << (max_manifest_size / 1024)
+                            << " KB)";
+                        all_valid = false;
+                    }
+                    else
+                    {
+                        LOG(INFO) << "✓ Manifest file size OK: " << filename
+                                  << " (" << (file_size / 1024) << " KB)";
+                    }
+                }
+                else
+                {
+                    LOG(INFO) << "Other file: " << filename << " (" << file_size
+                              << " bytes)";
+                }
+            }
+        }
+        catch (const std::exception &e)
+        {
+            LOG(ERROR) << "Error accessing store path " << store_path << ": "
+                       << e.what();
+            all_valid = false;
+        }
+    }
+
+    if (all_valid)
+    {
+        LOG(INFO) << "✓ All file sizes are within limits";
+    }
+    else
+    {
+        LOG(ERROR) << "✗ Some files exceed size limits";
+    }
+
+    return all_valid;
 }

--- a/tests/common.h
+++ b/tests/common.h
@@ -29,6 +29,8 @@ const eloqstore::KvOptions archive_opts = {
 
 eloqstore::EloqStore *InitStore(const eloqstore::KvOptions &opts);
 
+bool ValidateFileSizes(const eloqstore::KvOptions &opts);
+
 inline std::string_view ConvertIntKey(char *ptr, uint64_t key)
 {
     uint64_t big_endian = eloqstore::ToBigEndian(key);

--- a/tests/concurrency.cpp
+++ b/tests/concurrency.cpp
@@ -62,6 +62,9 @@ TEST_CASE("easy concurrency test", "[persist][concurrency]")
     ConcurrencyTester tester(store, "t1", 1, 32);
     tester.Init();
     tester.Run(20, 5, 32);
+
+    REQUIRE(ValidateFileSizes(default_opts));
+
     tester.Clear();
 }
 
@@ -78,6 +81,9 @@ TEST_CASE("hard concurrency test", "[persist][concurrency]")
     ConcurrencyTester tester(store, "t1", 10, 1000);
     tester.Init();
     tester.Run(5000, 10, 600);
+
+    REQUIRE(ValidateFileSizes(options));
+
     tester.Clear();
 }
 
@@ -92,5 +98,8 @@ TEST_CASE("stress append only mode", "[persist][append]")
     ConcurrencyTester tester(store, "t1", 4, 1024);
     tester.Init();
     tester.Run(1000, 10, 10);
+
+    REQUIRE(ValidateFileSizes(options));
+
     tester.Clear();
 }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file-size calculation to avoid overflow on large configurations, improving stability and accuracy.

* **Tests**
  * Added extensive file-size test cases covering varied page/file sizes, extreme and mixed scenarios, and massive data injection.
  * Integrated a validation utility to verify on-disk data and manifest sizes and invoked it from concurrency and stress tests.

* **Chores**
  * Added a new test target to build and run the expanded validation suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->