### PR TITLE
restrict absolute store path

### DIFF
--- a/eloq_store.cpp
+++ b/eloq_store.cpp
@@ -55,7 +55,7 @@ bool EloqStore::ValidateOptions(const KvOptions &opts)
         return false;
     }
 
-    for (const std::string &path: opts.store_path)
+    for (const std::string &path : opts.store_path)
     {
         if (path.empty() || !path.starts_with("/"))
         {


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for store paths to enforce absolute path requirements, ensuring the application properly handles and reports configuration errors when invalid paths are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->