### PR TITLE
make IndexPageIter::DecodeEntry inline

### DIFF
--- a/mem_index_page.cpp
+++ b/mem_index_page.cpp
@@ -216,10 +216,8 @@ void IndexPageIter::Invalidate()
     page_id_ = MaxPageId;
 }
 
-const char *IndexPageIter::DecodeEntry(const char *ptr,
-                                       const char *limit,
-                                       uint32_t *shared,
-                                       uint32_t *non_shared)
+__attribute__((always_inline)) inline const char *IndexPageIter::DecodeEntry(
+    const char *ptr, const char *limit, uint32_t *shared, uint32_t *non_shared)
 {
     if (limit - ptr < 2)
     {


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`

compiler cannot inline this function but this functon is called very frequently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal performance optimization and minor formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->