### PR TITLE
Avoid clean file parameter

### DIFF
--- a/eloq_store.cpp
+++ b/eloq_store.cpp
@@ -28,6 +28,8 @@
 #include "eloqstore_module.h"
 #endif
 
+DEFINE_bool(allow_reuse_local_files, false, "allow using local files");
+
 namespace eloqstore
 {
 
@@ -235,7 +237,8 @@ KvError EloqStore::InitStoreSpace()
                 LOG(ERROR) << "path " << store_path << " is not directory";
                 return KvError::InvalidArgs;
             }
-            if (cloud_store && !std::filesystem::is_empty(store_path))
+            if (cloud_store && !FLAGS_allow_reuse_local_files &&
+                !std::filesystem::is_empty(store_path))
             {
                 LOG(ERROR) << store_path
                            << " is not empty in cloud store mode, clear "


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud store mode now supports reusing existing local directories and files. Previously, initializing cloud store with a non-empty local path would result in an error. Users can now configure this behavior to allow reuse of pre-existing local data, providing greater flexibility and control in managing their local storage setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->