### PR TITLE
Fix BatchWriteTask::Reset by adding missed values to clear

### DIFF
--- a/batch_write_task.cpp
+++ b/batch_write_task.cpp
@@ -192,6 +192,11 @@ void BatchWriteTask::Reset(const TableIdent &tbl_id)
     idx_page_builder_.Reset();
     data_page_builder_.Reset();
     overflow_ptrs_.clear();
+    applying_page_.Clear();
+    for (DataPage &page : leaf_triple_)
+    {
+        page.Clear();
+    }
 }
 
 bool BatchWriteTask::SetBatch(std::span<WriteDataEntry> entries)


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup during batch write task reset to ensure complete state clearing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->