### PR TITLE
skip delete tree in partition truncate

### DIFF
--- a/batch_write_task.cpp
+++ b/batch_write_task.cpp
@@ -1608,15 +1608,6 @@ KvError BatchWriteTask::Truncate(std::string_view trunc_pos)
                 continue;
             }
 
-            if (val_type == MappingSnapshot::ValType::SwizzlingPointer)
-            {
-                auto *idx_page = reinterpret_cast<MemIndexPage *>(val);
-                mapping->Unswizzling(idx_page);
-                val = mapping_tbl[page_id];
-                val_type = MappingSnapshot::GetValType(val);
-                assert(val_type == MappingSnapshot::ValType::FilePageId);
-            }
-
             FreePage(page_id);
         }
 

--- a/write_task.cpp
+++ b/write_task.cpp
@@ -35,6 +35,7 @@ void WriteTask::Reset(const TableIdent &tbl_id)
 
 void WriteTask::Abort()
 {
+    LOG(INFO) << "WriteTask to " << tbl_ident_ << " is aborted";
     if (!Options()->data_append_mode)
     {
         IoMgr()->AbortWrite(tbl_ident_);


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More efficient full-partition truncation: mapped pages are recycled without traversing index trees, while TTL batch semantics are preserved.
  * Improved manifest/snapshot handling for empty partitions to ensure manifests remain consistent when write-ahead logs are empty.

* **Refactor**
  * Clarified and streamlined the decision paths for full vs. partial truncation.
  * Refined snapshot/manifest flow to handle empty snapshots explicitly and reduce unnecessary early exits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->