### PR TITLE
Fix TruncateDataPage to handle empty pages and tail maintenance

### DIFF
--- a/data_page.cpp
+++ b/data_page.cpp
@@ -112,9 +112,7 @@ DataPageIter::DataPageIter(const DataPage *data_page, const KvOptions *options)
       restart_offset_(data_page == nullptr
                           ? 0
                           : data_page->ContentLength() -
-                                (1 + restart_num_) * sizeof(uint16_t)),
-      curr_offset_(DataPage::content_offset),
-      curr_restart_idx_(0)
+                                (1 + restart_num_) * sizeof(uint16_t))
 {
 }
 
@@ -419,6 +417,7 @@ void DataPageIter::Invalidate()
     value_ = std::string_view{};
     expire_ts_ = 0;
     timestamp_ = 0;
+    overflow_ = false;
     compression_type_ = compression::CompressionType::None;
 }
 

--- a/data_page.h
+++ b/data_page.h
@@ -154,7 +154,7 @@ private:
     uint16_t RegionOffset(uint16_t region_idx) const;
     std::string_view page_;
     uint16_t cur_region_idx_{0};
-    uint16_t num_regions_;
+    uint16_t num_regions_{};
     const char *restart_array_{nullptr};
 };
 


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data truncation: detects overflow tails and performs cleanup only when needed.
  * Safer truncation path: empty pages are freed and page links updated to maintain correct tail pointers.
  * More robust iteration: defaults/resetting prevent uninitialized-state during iteration.
  * Tighter error handling during overflow cleanup to avoid partial/incorrect state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->