### PR TITLE
skip building dictionary when compression is not enable

### DIFF
--- a/compression.cpp
+++ b/compression.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "coding.h"
+#include "task.h"
 
 namespace eloqstore::compression
 {
@@ -194,7 +195,7 @@ void DictCompression::AddSample(const std::string &sample)
 void DictCompression::SampleAndBuildDictionaryIfNeeded(
     const std::span<WriteDataEntry> &entries)
 {
-    if (HasDictionary())
+    if (!Options()->enable_compression || HasDictionary())
     {
         return;
     }


### PR DESCRIPTION
A 20KB dictionary for each partition under range partition can be very costly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compression flag handling to properly prevent dictionary sampling and building when compression is disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->