### PR TITLE
fix yield crash

### DIFF
--- a/object_store.h
+++ b/object_store.h
@@ -91,7 +91,7 @@ public:
     {
     public:
         DownloadTask(const TableIdent *tbl_id, std::string_view filename)
-            : tbl_id_(tbl_id), filename_(filename) {};
+            : tbl_id_(tbl_id), filename_(filename){};
         Type TaskType() override
         {
             return Type::AsyncDownload;
@@ -104,7 +104,7 @@ public:
     {
     public:
         UploadTask(const TableIdent *tbl_id, std::string filename)
-            : tbl_id_(tbl_id), filename_(std::move(filename)) {};
+            : tbl_id_(tbl_id), filename_(std::move(filename)){};
         Type TaskType() override
         {
             return Type::AsyncUpload;
@@ -121,7 +121,7 @@ public:
     {
     public:
         explicit ListTask(std::string_view remote_path)
-            : remote_path_(remote_path) {};
+            : remote_path_(remote_path){};
         void SetRecursive(bool recurse)
         {
             recurse_ = recurse;
@@ -147,7 +147,7 @@ public:
     {
     public:
         explicit DeleteTask(std::string remote_path)
-            : remote_path_(std::move(remote_path)) {};
+            : remote_path_(std::move(remote_path)){};
         Type TaskType() override
         {
             return Type::AsyncDelete;
@@ -265,7 +265,9 @@ private:
                            std::string_view filename) const;
     std::string ComposeKeyFromRemote(std::string_view remote_path,
                                      bool ensure_trailing_slash) const;
-    void AcquireCloudSlot(KvTask *task, ObjectStore::Task *store_task);
+    bool AcquireCloudSlot(KvTask *task,
+                          ObjectStore::Task *store_task,
+                          bool is_retry);
     void ReleaseCloudSlot(ObjectStore::Task *store_task);
 };
 

--- a/task.cpp
+++ b/task.cpp
@@ -14,6 +14,15 @@ namespace eloqstore
 {
 void KvTask::Yield()
 {
+    // Check if we're in a valid coroutine context (running_ should be set to
+    // this task) If not, we're being called from external thread context (e.g.,
+    // ProcessPendingRetries) and main_ might be invalid. This is a programming
+    // error.
+    CHECK(shard && shard->running_ == this)
+        << "Yield() called outside coroutine context. running_="
+        << reinterpret_cast<void *>(shard->running_)
+        << ", this=" << reinterpret_cast<void *>(this)
+        << ". Yield() must only be called from within a coroutine.";
     shard->main_ = shard->main_.resume();
 }
 


### PR DESCRIPTION
Yield should only be called from coroutine context. ProcessPendingRetries called it without setting shard->main_ caused the crash.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud request slot acquisition now reports success/failure and schedules exponential backoff retries when capacity can't be obtained without blocking.
  * Submission flow updated so failed acquisitions reschedule requests instead of progressing without capacity.
  * Added defensive runtime checks to detect invalid coroutine/task context and abort early to prevent runtime corruption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->