### PR TITLE
Skip fd counting for open/close for upload and cloud file writes.

### DIFF
--- a/async_io_manager.cpp
+++ b/async_io_manager.cpp
@@ -2861,7 +2861,10 @@ KvError IouringMgr::ReadFile(const TableIdent &tbl_id,
     {
         LOG(ERROR) << "close file/directory " << fd
                    << " failed: " << strerror(-res);
-        status = ToKvError(res);
+        if (status == KvError::NoError)
+        {
+            status = ToKvError(res);
+        }
     }
     CHECK_KV_ERR(status);
     return KvError::NoError;
@@ -3331,7 +3334,10 @@ KvError CloudStoreMgr::WriteFile(const TableIdent &tbl_id,
     {
         LOG(ERROR) << "close file/directory " << fd
                    << " failed: " << strerror(-close_res);
-        status = ToKvError(close_res);
+        if (status == KvError::NoError)
+        {
+            status = ToKvError(close_res);
+        }
     }
     if (status == KvError::NoError && close_res < 0)
     {


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * File open/create and close paths now perform fully asynchronous I/O for reads and writes, improving responsiveness and throughput.
  * Error logging and propagation updated to reflect asynchronous operation results. No public or exported interfaces changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->