### PR TITLE
Inline KvOptions data file helpers

### DIFF
--- a/include/kv_options.h
+++ b/include/kv_options.h
@@ -171,8 +171,15 @@ struct KvOptions
      */
     uint16_t data_page_size = 4 * KB;
 
-    size_t FilePageOffsetMask() const;
-    size_t DataFileSize() const;
+    size_t FilePageOffsetMask() const
+    {
+        return (1 << pages_per_file_shift) - 1;
+    }
+
+    size_t DataFileSize() const
+    {
+        return static_cast<size_t>(data_page_size) << pages_per_file_shift;
+    }
     /**
      * @brief Amount of pages per data file (1 << pages_per_file_shift).
      * It is recommended to set a smaller file size like 4MB in append write

--- a/src/kv_options.cpp
+++ b/src/kv_options.cpp
@@ -9,8 +9,6 @@
 #include <limits>
 #include <string>
 #include <string_view>
-#include <system_error>
-#include <utility>
 #include <vector>
 
 #include "inih/cpp/INIReader.h"
@@ -346,15 +344,5 @@ bool KvOptions::operator==(const KvOptions &other) const
            pages_per_file_shift == other.pages_per_file_shift &&
            overflow_pointers == other.overflow_pointers &&
            data_append_mode == other.data_append_mode;
-}
-
-size_t KvOptions::FilePageOffsetMask() const
-{
-    return (1 << pages_per_file_shift) - 1;
-}
-
-size_t KvOptions::DataFileSize() const
-{
-    return static_cast<size_t>(data_page_size) << pages_per_file_shift;
 }
 }  // namespace eloqstore


### PR DESCRIPTION
Define KvOptions::FilePageOffsetMask and KvOptions::DataFileSize directly in kv_options.h so simple page-size helpers are available wherever the struct is included, without needing the .cpp. This can help upper repo to get rid of INIReader