### PR TITLE
chore: solve compile warning by marking maybe unused variables

### DIFF
--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -1474,7 +1474,7 @@ KvError IouringMgr::AppendManifest(const TableIdent &tbl_id,
 
     TEST_KILL_POINT_WEIGHT("AppendManifest:Write", 10)
 
-    const size_t alignment = page_align;
+    [[maybe_unused]] const size_t alignment = page_align;
     assert((offset & (alignment - 1)) == 0);
     assert((log.size() & (alignment - 1)) == 0);
 
@@ -1510,7 +1510,7 @@ int IouringMgr::WriteSnapshot(LruFD::Ref dir_fd,
 
     const char *write_ptr = content.data();
     size_t io_size = content.size();
-    const size_t alignment = page_align;
+    [[maybe_unused]] const size_t alignment = page_align;
     assert((io_size & (alignment - 1)) == 0);
     assert((reinterpret_cast<uintptr_t>(write_ptr) & (alignment - 1)) == 0);
     int res = Write({tmp_fd, false}, write_ptr, io_size, 0);
@@ -1520,7 +1520,7 @@ int IouringMgr::WriteSnapshot(LruFD::Ref dir_fd,
         LOG(ERROR) << "write temporary file failed " << strerror(-res);
         return res;
     }
-    if (res < io_size)
+    if (res < static_cast<int>(io_size))
     {
         Close(tmp_fd);
         LOG(ERROR) << "write temporary file less than expected.";
@@ -3281,8 +3281,8 @@ KvError CloudStoreMgr::WriteFile(const TableIdent &tbl_id,
 
     KvError status = KvError::NoError;
     const size_t padded_size = buffer.padded_size();
-    const size_t logical_size = buffer.size();
-    const size_t alignment = buffer.alignment();
+    [[maybe_unused]] const size_t logical_size = buffer.size();
+    [[maybe_unused]] const size_t alignment = buffer.alignment();
     const char *write_ptr = buffer.data();
 
     assert(write_ptr != nullptr);


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric comparison safety in I/O operations to prevent type mismatch issues.

* **Chores**
  * Refined compiler warning handling and internal code clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->