### PR TITLE
add some parameter on db-stress

### DIFF
--- a/db_stress/README.md
+++ b/db_stress/README.md
@@ -65,9 +65,9 @@ There are two groups of knobs:
   - `--db_path`, `--cloud_store_path`, `--num_threads`
   - `--data_append_mode`, `--pages_per_file_shift`, `--data_page_size`
   - `--buffer_pool_size`, `--io_queue_size`, `--fd_limit`
+  - `--enable_compression`, `--dict_cache_size`
   - `--manifest_limit`, `--init_page_count`
   - `--max_inflight_write`, `--max_write_batch_pages`
   - `--file_amplify_factor`, `--local_space_limit`, `--reserve_space_ratio`
   - `--overflow_pointers`, `--data_page_restart_interval`,
     `--index_page_restart_interval`
-

--- a/db_stress/db_stress_common.h
+++ b/db_stress/db_stress_common.h
@@ -27,6 +27,7 @@ DECLARE_uint32(keys_per_batch);
 DECLARE_bool(syn_scan);
 
 DECLARE_string(db_path);
+DECLARE_bool(clean_data_dir_on_start);
 
 DECLARE_string(options);
 DECLARE_uint32(n_tables);
@@ -41,6 +42,8 @@ DECLARE_uint32(index_page_restart_interval);
 DECLARE_uint32(index_page_read_queue);
 DECLARE_uint32(init_page_count);
 DECLARE_uint32(buffer_pool_size);
+DECLARE_bool(enable_compression);
+DECLARE_uint64(dict_cache_size);
 DECLARE_uint64(manifest_limit);
 DECLARE_uint32(fd_limit);
 DECLARE_uint32(io_queue_size);

--- a/db_stress/db_stress_driver.cpp
+++ b/db_stress/db_stress_driver.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -111,6 +112,24 @@ void RunStressTest(int argc, char **argv)
     FLAGS_stderrthreshold = google::GLOG_WARNING;
     FLAGS_logbuflevel = google::GLOG_INFO;
 
+    if (FLAGS_clean_data_dir_on_start)
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(FLAGS_db_path, ec);
+        if (ec)
+        {
+            LOG(WARNING) << "Failed to clean db_path: " << FLAGS_db_path
+                         << " error=" << ec.message();
+        }
+        std::filesystem::remove_all(FLAGS_shared_state_path, ec);
+        if (ec)
+        {
+            LOG(WARNING) << "Failed to clean shared_state_path: "
+                         << FLAGS_shared_state_path
+                         << " error=" << ec.message();
+        }
+    }
+
     eloqstore::KvOptions opts;
     if (!FLAGS_options.empty())
     {
@@ -129,6 +148,8 @@ void RunStressTest(int argc, char **argv)
         opts.data_page_restart_interval = FLAGS_data_page_restart_interval;
         opts.index_page_restart_interval = FLAGS_index_page_restart_interval;
         opts.buffer_pool_size = FLAGS_buffer_pool_size;
+        opts.enable_compression = FLAGS_enable_compression;
+        opts.dict_cache_size = FLAGS_dict_cache_size;
         opts.io_queue_size = FLAGS_io_queue_size;
         opts.fd_limit = FLAGS_fd_limit;
         opts.manifest_limit = FLAGS_manifest_limit;

--- a/db_stress/db_stress_gflags.cpp
+++ b/db_stress/db_stress_gflags.cpp
@@ -34,7 +34,10 @@ DEFINE_string(db_path, "data/stress_test", "Path to database");
 DEFINE_string(shared_state_path,
               "data/db_stress_helper",
               "Path to shared state directory");
-DEFINE_uint32(n_tables, 10, "nums of threads/tables");
+DEFINE_bool(clean_data_dir_on_start,
+            true,
+            "clean db_path  and shared_state_path when starting db_stress");
+DEFINE_uint32(n_tables, 1, "nums of threads/tables");
 DEFINE_uint32(n_partitions, 10, "nums of partitions");
 // I think it is better to set a large value for ops_per_partition
 DEFINE_uint64(ops_per_partition,
@@ -78,11 +81,15 @@ DEFINE_bool(syn_scan, true, "choose scan syn or asyn");
 DEFINE_uint32(shortest_value, 1024, "minimum value size in bytes");
 DEFINE_uint32(longest_value, 40960, "maximum value size in bytes");
 // random params for crash_test
-DEFINE_uint32(num_threads, 8, "Amount of threads");
+DEFINE_uint32(num_threads, 1, "Amount of threads");
 DEFINE_uint32(data_page_restart_interval, 16, "interval of datapage restart");
 DEFINE_uint32(index_page_restart_interval, 16, "interval of indexpage restart");
 DEFINE_uint32(init_page_count, 1 << 15, "nums of init page");
-DEFINE_uint32(buffer_pool_size, 1 << 15, "size of shared buffer pool in bytes");
+DEFINE_uint32(buffer_pool_size, 1 << 30, "size of shared buffer pool in bytes");
+DEFINE_bool(enable_compression, false, "enable dictionary compression");
+DEFINE_uint64(dict_cache_size,
+              64ULL << 20,
+              "max size of cached compression dictionaries (bytes)");
 DEFINE_uint64(manifest_limit, 16 << 20, "limit of manifest");
 DEFINE_uint32(fd_limit, 10000, "limit of fd");
 DEFINE_uint32(io_queue_size, 4096, "size of io_queue");


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compression and dictionary cache configuration options
  * Introduced latency and throughput monitoring capabilities
  * Added directory cleanup option on startup
  * Expanded tunable parameters for memory, I/O, and archival behavior

* **Chores**
  * Updated default values for parallelism and table configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->