### PR TITLE
fix: correct simple benchmark write throughput

### DIFF
--- a/benchmark/simple_bench.cpp
+++ b/benchmark/simple_bench.cpp
@@ -175,6 +175,7 @@ void WriteLoop(eloqstore::EloqStore *store)
     bool recorded_write_latency = false;
     auto total_start = high_resolution_clock::now();
     auto window_start = total_start;
+    uint64_t last_logged_batches = 0;
     const double min_window_ms =
         std::max(1.0, FLAGS_write_stats_interval_sec * 1000.0);
     for (auto &writer : writers)
@@ -206,8 +207,10 @@ void WriteLoop(eloqstore::EloqStore *store)
             {
                 continue;
             }
+            const uint64_t completed_batches = i - last_logged_batches;
+            last_logged_batches = i;
             const uint64_t num_kvs =
-                uint64_t(FLAGS_batch_size) * FLAGS_partitions;
+                uint64_t(FLAGS_batch_size) * completed_batches;
             const uint64_t kvs_per_sec = num_kvs * 1000 / cost_ms;
             const double upsert_ratio_current = FLAGS_load ? 1.0 : upsert_ratio;
             const uint64_t mb_per_sec =


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of throughput metrics calculation in performance logging by properly tracking completed batches within each logging window rather than using total partition counts.

* **Refactor**
  * Updated performance measurement window flow to use actual completed batch counts for more precise throughput statistics reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->