### PR TITLE
Insert YieldToNextRound in compaction to avoid affecting online tasks 

### DIFF
--- a/include/file_gc.h
+++ b/include/file_gc.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <string>
-#include <unordered_set>
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "error.h"
 #include "kv_options.h"
 #include "storage/object_store.h"
@@ -13,7 +13,7 @@
 
 namespace eloqstore
 {
-void GetRetainedFiles(std::unordered_set<FileId> &result,
+void GetRetainedFiles(absl::flat_hash_set<FileId> &result,
                       const MappingSnapshot::MappingTbl &tbl,
                       uint8_t pages_per_file_shift);
 
@@ -25,12 +25,12 @@ namespace FileGarbageCollector
 {
 // Local mode method (direct execution)
 KvError ExecuteLocalGC(const TableIdent &tbl_id,
-                       const std::unordered_set<FileId> &retained_files,
+                       const absl::flat_hash_set<FileId> &retained_files,
                        IouringMgr *io_mgr);
 
 // Cloud mode method (coroutine-based)
 KvError ExecuteCloudGC(const TableIdent &tbl_id,
-                       const std::unordered_set<FileId> &retained_files,
+                       const absl::flat_hash_set<FileId> &retained_files,
                        CloudStoreMgr *cloud_mgr);
 
 // Local mode implementation
@@ -41,7 +41,7 @@ KvError ListLocalFiles(const TableIdent &tbl_id,
 KvError DeleteUnreferencedLocalFiles(
     const TableIdent &tbl_id,
     const std::vector<std::string> &data_files,
-    const std::unordered_set<FileId> &retained_files,
+    const absl::flat_hash_set<FileId> &retained_files,
     FileId least_not_archived_file_id,
     IouringMgr *io_mgr);
 
@@ -73,7 +73,7 @@ FileId ParseArchiveForMaxFileId(std::string_view archive_content);
 KvError DeleteUnreferencedCloudFiles(
     const TableIdent &tbl_id,
     const std::vector<std::string> &data_files,
-    const std::unordered_set<FileId> &retained_files,
+    const absl::flat_hash_set<FileId> &retained_files,
     FileId least_not_archived_file_id,
     CloudStoreMgr *cloud_mgr);
 }  // namespace FileGarbageCollector

--- a/include/storage/page_mapper.h
+++ b/include/storage/page_mapper.h
@@ -18,7 +18,7 @@ class ManifestBuilder;
 class ManifestBuffer;
 struct KvOptions;
 
-struct MappingSnapshot
+struct MappingSnapshot : public std::enable_shared_from_this<MappingSnapshot>
 {
     class MappingTbl
     {

--- a/include/tasks/background_write.h
+++ b/include/tasks/background_write.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include "tasks/write_task.h"
 
 namespace eloqstore
@@ -18,5 +21,9 @@ public:
     KvError CompactDataFile();
 
     KvError CreateArchive();
+
+private:
+    void HeapSortFpIdsWithYield(
+        std::vector<std::pair<FilePageId, PageId>> &fp_ids);
 };
 }  // namespace eloqstore


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [x] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved file garbage collection internals for faster, more memory-efficient set handling and cooperative yielding to reduce long blocking work.
  * Enhanced background write/compaction with yield-aware sorting, more granular progress points, and clearer log messages for better responsiveness and observability.
  * Mapping snapshot handling updated to better support shared usage patterns during background tasks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->