### PR TITLE
feat: make Aws::Client::ClientConfiguration static to fast startup

### DIFF
--- a/src/storage/object_store.cpp
+++ b/src/storage/object_store.cpp
@@ -784,10 +784,14 @@ protected:
 
     const Aws::Client::ClientConfiguration &GetClientConfig() const
     {
-        std::call_once(client_config_once_, [this]() {
-            client_config_ = std::make_unique<Aws::Client::ClientConfiguration>(
-                BuildClientConfig());
-        });
+        std::call_once(
+            client_config_once_,
+            [this]
+            {
+                client_config_ =
+                    std::make_unique<Aws::Client::ClientConfiguration>(
+                        BuildClientConfig());
+            });
         return *client_config_;
     }
 


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and lazily initialized AWS client configuration so storage clients reuse a shared configuration.
  * Results in faster startup, reduced resource usage, and more consistent region handling for AWS-backed storage operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->