### PR TITLE
fix io_uring teardown when IouringMgr is not initialized

### DIFF
--- a/include/async_io_manager.h
+++ b/include/async_io_manager.h
@@ -533,6 +533,7 @@ public:
     std::vector<Page> bufs_pool_;
     const int buf_group_{0};
 
+    bool ring_inited_{false};
     io_uring ring_;
     WaitingZone waiting_sqe_;
     uint32_t prepared_sqe_{0};


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved async I/O initialization and cleanup handling to prevent potential errors during resource shutdown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->