### PR TITLE
chore: change minio port to 9900

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ wget https://dl.min.io/server/minio/release/linux-amd64/minio
 chmod +x minio
 
 # Start MinIO server (runs on port 9000 by default)
-./minio server /tmp/minio-data --console-address ":9901"
+./minio server /tmp/minio-data --address :9900 --console-address :9901
 ```
 
 **2. Run unit tests:**


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MinIO startup and console port references to new addresses and ports.
  * Removed the test bucket creation and related setup steps from the setup guide.
  * Renumbered the unit tests section header and preserved the unit test execution command.
  * Clarified the default service endpoint in notes to match the updated ports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->