### PR TITLE
feat: introduce parameter for compression level

### DIFF
--- a/include/compression.h
+++ b/include/compression.h
@@ -73,7 +73,7 @@ public:
     bool Decompress(std::string_view input, std::string &output) const;
 
 private:
-    bool EnsureZstdObjects();
+    bool EnsureZstdObjects(int compression_level);
 
     bool dirty_{false};
     bool has_dictionary_{false};
@@ -92,7 +92,9 @@ struct PreparedValue
     CompressionType compression_kind{CompressionType::None};
 };
 
-bool CompressRaw(std::string_view input, std::string &output);
+bool CompressRaw(std::string_view input,
+                 std::string &output,
+                 int compression_level);
 bool DecompressRaw(std::string_view input, std::string &output);
 
 PreparedValue Prepare(std::string_view value,

--- a/include/kv_options.h
+++ b/include/kv_options.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <zstd.h>
+
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -218,6 +220,11 @@ struct KvOptions
      * @brief Compression is enabled.
      */
     bool enable_compression = false;
+    /**
+     * @brief The compression level to use when compression is enabled.
+     * Use ZSTD_CLEVEL_DEFAULT by default.
+     */
+    int zstd_compression_level = ZSTD_CLEVEL_DEFAULT;
     /**
      * @brief Download recent files from cloud into local cache during startup.
      * The partition filter returning true means that this table partition


### PR DESCRIPTION
modify Compression.h & Compression.cpp
In the two functions CompressRaw and DictCompression::EnsureZstdObjects, the global variable kCompressionLevel is no longer used, and instead the default parameter compression_level is used

但是,当前的main分支本地Release编译后进行测试，会崩溃在第28个测试点；我的修改不影响测试的正确性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compression now supports a configurable Zstandard compression level across compression and dictionary workflows.
  * Added a public option to set the ZSTD compression level (defaults preserve previous behavior), allowing tuning of speed vs. ratio.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->