### PR TITLE
fix: prevent MappingSnapshot UAF after shard stop

### DIFF
--- a/include/storage/page_mapper.h
+++ b/include/storage/page_mapper.h
@@ -96,6 +96,9 @@ struct MappingSnapshot : public std::enable_shared_from_this<MappingSnapshot>
 
     void Serialize(ManifestBuffer &dst) const;
 
+    // Destructors often run on non-shard threads (e.g. Stop() callers) where
+    // TLS `shard` is invalid, so we rely on idx_mgr_ to reclaim resources. It
+    // remains valid until RootMetaMgr::ReleaseMappers() clears snapshots.
     IndexPageManager *idx_mgr_;
     const TableIdent *tbl_ident_;
 

--- a/src/storage/page_mapper.cpp
+++ b/src/storage/page_mapper.cpp
@@ -334,11 +334,15 @@ uint64_t MappingSnapshot::DecodeId(uint64_t val)
 
 MappingSnapshot::~MappingSnapshot()
 {
-    idx_mgr_->FreeMappingSnapshot(this);
-    if (shard != nullptr)
+    IndexPageManager *mgr = idx_mgr_;
+    if (mgr == nullptr)
     {
-        shard->IndexManager()->MapperArena()->Release(std::move(mapping_tbl_));
+        return;
     }
+
+    mgr->FreeMappingSnapshot(this);
+
+    mgr->MapperArena()->Release(std::move(mapping_tbl_));
 }
 
 FilePageId MappingSnapshot::ToFilePage(PageId page_id) const

--- a/src/storage/root_meta.cpp
+++ b/src/storage/root_meta.cpp
@@ -307,7 +307,13 @@ void RootMetaMgr::ReleaseMappers()
 {
     for (auto &it : entries_)
     {
-        it.second.meta_.mapper_ = nullptr;
+        RootMeta &meta = it.second.meta_;
+        for (MappingSnapshot *snapshot : meta.mapping_snapshots_)
+        {
+            snapshot->idx_mgr_ = nullptr;
+        }
+        meta.mapping_snapshots_.clear();
+        meta.mapper_ = nullptr;
     }
 }
 


### PR DESCRIPTION
- stop relying on TLS shard during MappingSnapshot teardown; if its IndexPageManager is still alive, call FreeMappingSnapshot and return the pooled table through MapperArena(), otherwise bail out
- ensure RootMetaMgr::ReleaseMappers() clears mapping_snapshots_ and nulls every snapshot’s idx_mgr_ so late destructors never dereference a freed manager 
- document that idx_mgr_ is used for teardown because destructors often run on non-shard threads (e.g. EloqStore::Stop() callers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource cleanup and object destruction mechanisms to improve storage system stability and prevent potential issues in edge case scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->