### PR TITLE
fix: double free memindex page in dirtyPage

### DIFF
--- a/include/storage/mem_index_page.h
+++ b/include/storage/mem_index_page.h
@@ -67,6 +67,11 @@ public:
         return prev_ == nullptr && next_ == nullptr;
     }
 
+    bool InFreeList() const
+    {
+        return in_free_list_;
+    }
+
     PageId GetPageId() const
     {
         return page_id_;
@@ -124,6 +129,7 @@ private:
     MemIndexPage *next_{nullptr};
     MemIndexPage *prev_{nullptr};
     const TableIdent *tbl_ident_{nullptr};
+    bool in_free_list_{false};
     friend class IndexPageManager;
 };
 

--- a/src/storage/index_page_manager.cpp
+++ b/src/storage/index_page_manager.cpp
@@ -84,6 +84,7 @@ MemIndexPage *IndexPageManager::AllocIndexPage()
     }
     assert(next_free->IsDetached());
     assert(!next_free->IsPinned());
+    next_free->in_free_list_ = false;
     return next_free;
 }
 
@@ -91,6 +92,7 @@ void IndexPageManager::FreeIndexPage(MemIndexPage *page)
 {
     assert(page->IsDetached());
     assert(!page->IsPinned());
+    page->in_free_list_ = true;
     free_head_.EnqueNext(page);
 }
 

--- a/src/tasks/batch_write_task.cpp
+++ b/src/tasks/batch_write_task.cpp
@@ -983,6 +983,11 @@ BatchWriteTask::DirtyIndexPage::~DirtyIndexPage()
 {
     if (page_ != nullptr)
     {
+        if (page_->InFreeList())
+        {
+            page_ = nullptr;
+            return;
+        }
         assert(page_->IsDetached());
         shard->IndexManager()->FreeIndexPage(page_);
         page_ = nullptr;


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tracking of memory page allocation states to prevent invalid operations on freed pages.
  * Improved cleanup and resource management in batch write operations for more reliable page lifecycle handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->