### PR TITLE
chore:decrease direct_io_buffer_pool_size to 16 to save memory

### DIFF
--- a/include/kv_options.h
+++ b/include/kv_options.h
@@ -126,7 +126,7 @@ struct KvOptions
     /**
      * @brief Max cached DirectIO buffers per shard.
      */
-    uint32_t direct_io_buffer_pool_size = 128;
+    uint32_t direct_io_buffer_pool_size = 16;
     /**
      * @brief Size of each write buffer used for append-mode aggregation.
      * Only take effect when data_append_mode is enabled.


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced default DirectIO buffer caching limit to optimize memory consumption without affecting core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->