### PR TITLE
fix: fix rust compile by adding reopen_task definition

### DIFF
--- a/rust/eloqstore-sys/vendor/CMakeLists.txt
+++ b/rust/eloqstore-sys/vendor/CMakeLists.txt
@@ -414,6 +414,7 @@ set(ELOQ_STORE_SOURCES
         src/tasks/write_buffer_aggregator.cpp
         src/tasks/prewarm_task.cpp
         src/tasks/read_task.cpp
+        src/tasks/reopen_task.cpp
         src/tasks/scan_task.cpp
         src/tasks/task.cpp
         src/tasks/task_manager.cpp


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`
