### PR TITLE
fix: use rename to avoid partial download

### DIFF
--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -4329,9 +4329,19 @@ KvError CloudStoreMgr::DownloadFile(const TableIdent &tbl_id,
         return download_task.error_;
     }
 
-    KvError err = WriteFile(tbl_id, filename, download_task.response_data_);
+    std::string tmp_filename = filename + ".tmp";
+    KvError err = WriteFile(tbl_id, tmp_filename, download_task.response_data_);
     ReleaseCloudBuffer(std::move(download_task.response_data_));
     CHECK_KV_ERR(err);
+
+    auto [dir_fd, dir_err] = OpenFD(tbl_id, LruFD::kDirectory, false, 0);
+    CHECK_KV_ERR(dir_err);
+
+    int res = Rename(dir_fd.FdPair(), tmp_filename.c_str(), filename.c_str());
+    if (res < 0)
+    {
+        return ToKvError(res);
+    }
     return KvError::NoError;
 }
 


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability through atomic file operations. Files are now written completely and verified before being saved to their final location. This prevents partial or corrupted downloads from persisting on your system, ensuring all downloaded content remains safe and complete. This change enhances overall data integrity when downloading files through the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->