### PR TITLE
fix: add lock before notify at KvRequest::SetDone

### DIFF
--- a/src/eloq_store.cpp
+++ b/src/eloq_store.cpp
@@ -1444,6 +1444,7 @@ void KvRequest::SetDone(KvError err)
     {
         // Synchronous request
 #ifdef ELOQ_MODULE_ENABLED
+        std::lock_guard<bthread::Mutex> lk(req->mutex_);
         cv_.notify_one();
 #else
         done_.notify_one();


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`
