### PR TITLE
fix: KvRequest::SetDone and use only one lock

### DIFF
--- a/src/eloq_store.cpp
+++ b/src/eloq_store.cpp
@@ -1428,28 +1428,31 @@ void KvRequest::SetDone(KvError err)
 {
     err_ = err;
 #ifdef ELOQ_MODULE_ENABLED
+    bool has_async_cb = false;
     {
         std::lock_guard<bthread::Mutex> lk(mutex_);
         done_ = true;
+        has_async_cb = (callback_ != nullptr);
+        if (!has_async_cb)
+        {
+            cv_.notify_one();
+        }
+    }
+    if (has_async_cb)
+    {
+        callback_(this);
     }
 #else
     done_.store(true, std::memory_order_release);
-#endif
     if (callback_)
     {
-        // Asynchronous request
         callback_(this);
     }
     else
     {
-        // Synchronous request
-#ifdef ELOQ_MODULE_ENABLED
-        std::lock_guard<bthread::Mutex> lk(req->mutex_);
-        cv_.notify_one();
-#else
         done_.notify_one();
-#endif
     }
+#endif
 }
 
 }  // namespace eloqstore


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal request completion handling and asynchronous callback processing logic.

---

**Note:** This release contains internal improvements with no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->