### PR TITLE
fix: reopen nonexistent partitions clean local partitions and clean empty directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ target
 tmp
 compile_commands.json
 .pre-commit-config.yaml
+
+.codex

--- a/include/async_io_manager.h
+++ b/include/async_io_manager.h
@@ -321,7 +321,7 @@ public:
                    // implementations
     }
 
-    virtual void CleanManifest(const TableIdent &tbl_id) = 0;
+    virtual KvError CleanManifest(const TableIdent &tbl_id) = 0;
     virtual void RegisterDirBusy(const TableIdent &tbl_id)
     {
         (void) tbl_id;
@@ -551,7 +551,7 @@ public:
     }
 
     virtual KvError TryCleanupLocalPartitionDir(const TableIdent &tbl_id);
-    void CleanManifest(const TableIdent &tbl_id) override;
+    KvError CleanManifest(const TableIdent &tbl_id) override;
 
     static constexpr uint64_t oflags_dir = O_DIRECTORY | O_RDONLY;
 
@@ -904,7 +904,7 @@ public:
                               std::string_view branch_name,
                               uint64_t term) override;
     KvError AbortWrite(const TableIdent &tbl_id) override;
-    void CleanManifest(const TableIdent &tbl_id) override;
+    KvError CleanManifest(const TableIdent &tbl_id) override;
 
     ObjectStore &GetObjectStore()
     {
@@ -1023,8 +1023,9 @@ public:
     std::pair<ManifestFilePtr, KvError> RefreshManifest(
         const TableIdent &tbl_id, std::string_view archive_tag);
     KvError TryCleanupLocalPartitionDir(const TableIdent &tbl_id) override;
-    void RequestGcLocalCleanup(const TableIdent &tbl_id,
-                               const std::vector<std::string> &filenames);
+    KvError CleanupLocalPartitionFiles(const TableIdent &tbl_id);
+    void ScheduleLocalFileCleanup(const TableIdent &tbl_id,
+                                  const std::vector<std::string> &filenames);
     void RegisterDirBusy(const TableIdent &tbl_id) override;
     void UnregisterDirBusy(const TableIdent &tbl_id) override;
     bool HasDirBusy(const TableIdent &tbl_id) const override;
@@ -1334,7 +1335,7 @@ public:
         return 0;  // MemStoreMgr doesn't use local file caching
     }
 
-    void CleanManifest(const TableIdent &tbl_id) override;
+    KvError CleanManifest(const TableIdent &tbl_id) override;
 
     class Manifest : public ManifestFile
     {

--- a/include/eloq_store.h
+++ b/include/eloq_store.h
@@ -408,9 +408,20 @@ public:
     {
         return tag_;
     }
+    // `clean=true` means reopen should accept a missing remote snapshot and
+    // replace any existing local partition state with an empty snapshot.
+    void SetClean(bool clean)
+    {
+        clean_ = clean;
+    }
+    bool Clean() const
+    {
+        return clean_;
+    }
 
 private:
     std::string tag_;
+    bool clean_{false};
 
     friend class EloqStore;
     friend class ReopenTask;

--- a/include/file_gc.h
+++ b/include/file_gc.h
@@ -65,8 +65,7 @@ void ClassifyFiles(const std::vector<std::string> &files,
 KvError ReadCloudFile(const TableIdent &tbl_id,
                       const std::string &cloud_file,
                       DirectIoBuffer &content,
-                      CloudStoreMgr *cloud_mgr,
-                      const KvOptions *options);
+                      CloudStoreMgr *cloud_mgr);
 
 KvError DeleteUnreferencedCloudFiles(
     const TableIdent &tbl_id,

--- a/include/storage/index_page_manager.h
+++ b/include/storage/index_page_manager.h
@@ -60,9 +60,12 @@ public:
                                                       PageId page_id);
     // Install an externally built snapshot (e.g. pulled from remote manifest)
     // into the RootMeta version chain without performing local COW writes.
+    // A missing external manifest falls back to installing an empty snapshot.
     KvError InstallExternalSnapshot(const TableIdent &tbl_ident,
                                     CowRootMeta &cow_meta,
                                     std::string_view reopen_tag = {});
+    KvError InstallEmptySnapshot(const TableIdent &tbl_ident,
+                                 CowRootMeta &cow_meta);
 
     void FreeMappingSnapshot(MappingSnapshot *mapping);
 

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -566,7 +566,7 @@ KvError IouringMgr::ReadPages(const TableIdent &tbl_id,
             : BaseReq(task),
               offset_(offset),
               fd_ref_(std::move(fd)),
-              page_(true) {};
+              page_(true){};
 
         bool done_{false};
         uint32_t offset_;
@@ -1714,7 +1714,7 @@ KvError IouringMgr::FdatasyncFiles(const TableIdent &tbl_id,
     struct FsyncReq : BaseReq
     {
         FsyncReq(KvTask *task, LruFD::Ref fd)
-            : BaseReq(task), fd_ref_(std::move(fd)) {};
+            : BaseReq(task), fd_ref_(std::move(fd)){};
         LruFD::Ref fd_ref_;
     };
 
@@ -1771,7 +1771,7 @@ KvError IouringMgr::CloseFiles(std::span<LruFD::Ref> fds)
     struct CloseReq : BaseReq
     {
         CloseReq(KvTask *task, LruFD::Ref fd)
-            : BaseReq(task), fd_ref_(std::move(fd)) {};
+            : BaseReq(task), fd_ref_(std::move(fd)){};
         LruFD::Ref fd_ref_;
         int reg_idx_{-1};
         int fd_{LruFD::FdEmpty};
@@ -4620,8 +4620,14 @@ KvError CloudStoreMgr::CleanManifest(const TableIdent &tbl_id)
     {
         return err;
     }
-    (void) DequeClosedFile(FileKey(
-        tbl_id, BranchManifestFileName(GetActiveBranch(), ProcessTerm())));
+    if (DequeClosedFile(FileKey(
+            tbl_id, BranchManifestFileName(GetActiveBranch(), ProcessTerm()))))
+    {
+        const size_t manifest_size = options_->manifest_limit;
+        used_local_space_ = used_local_space_ > manifest_size
+                                ? used_local_space_ - manifest_size
+                                : 0;
+    }
     if (!HasTrackedLocalFiles(tbl_id))
     {
         KvError cleanup_err = TryCleanupLocalPartitionDir(tbl_id);
@@ -6296,7 +6302,7 @@ void CloudStoreMgr::FileCleaner::Shutdown()
     coro_ = coro_.resume();
 }
 
-MemStoreMgr::MemStoreMgr(const KvOptions *opts) : AsyncIoManager(opts) {};
+MemStoreMgr::MemStoreMgr(const KvOptions *opts) : AsyncIoManager(opts){};
 
 KvError MemStoreMgr::Init(Shard *shard)
 {

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -784,9 +784,6 @@ KvError IouringMgr::SubmitMergedWrite(const TableIdent &tbl_id,
     const bool skip_cloud_lookup =
         options_->data_append_mode && !options_->cloud_store_path.empty() &&
         file_id <= LruFD::kMaxDataFile && offset == 0;
-    DLOG(INFO) << "SubmitMergedWrite, tbl=" << tbl_id << " file_id=" << file_id
-               << " branch=" << branch << " term=" << term
-               << " offset=" << offset << " bytes=" << bytes;
     OnFileRangeWritePrepared(tbl_id,
                              file_id,
                              branch,
@@ -796,11 +793,6 @@ KvError IouringMgr::SubmitMergedWrite(const TableIdent &tbl_id,
     auto [fd_ref, err] = OpenOrCreateFD(
         tbl_id, file_id, true, true, branch, term, skip_cloud_lookup);
     CHECK_KV_ERR(err);
-    DLOG(INFO) << "SubmitMergedWrite after OpenOrCreateFD, tbl=" << tbl_id
-               << " file_id=" << file_id
-               << " fd_branch=" << fd_ref.Get()->branch_name_
-               << " fd_term=" << fd_ref.Get()->term_
-               << " reg_idx=" << fd_ref.Get()->reg_idx_;
     fd_ref.Get()->dirty_ = true;
 
     auto *req =
@@ -1007,55 +999,63 @@ KvError CloudStoreMgr::TryCleanupLocalPartitionDir(const TableIdent &tbl_id)
     return IouringMgr::TryCleanupLocalPartitionDir(tbl_id);
 }
 
-void IouringMgr::CleanManifest(const TableIdent &tbl_id)
+KvError IouringMgr::CleanManifest(const TableIdent &tbl_id)
 {
     if (HasOtherFile(tbl_id))
     {
         DLOG(INFO) << "Skip cleaning manifest for " << tbl_id
                    << " because other files are present";
-        return;
+        return KvError::Busy;
     }
 
     uint64_t process_term = ProcessTerm();
     KvError dir_err = KvError::NoError;
+    auto [dir_fd, err] = OpenFD(tbl_id, LruFD::kDirectory, false, "", 0);
+    dir_err = err;
+    if (dir_err == KvError::NoError)
     {
-        auto [dir_fd, err] = OpenFD(tbl_id, LruFD::kDirectory, false, "", 0);
-        dir_err = err;
-        if (dir_err == KvError::NoError)
+        const std::string manifest_name =
+            BranchManifestFileName(GetActiveBranch(), process_term);
+        int res = UnlinkAt(dir_fd.FdPair(), manifest_name.c_str(), false);
+        if (res < 0 && res != -ENOENT)
         {
-            const std::string manifest_name =
-                BranchManifestFileName(GetActiveBranch(), process_term);
-            int res = UnlinkAt(dir_fd.FdPair(), manifest_name.c_str(), false);
-            if (res < 0 && res != -ENOENT)
-            {
-                LOG(ERROR) << "Failed to delete manifest file for table "
-                           << tbl_id << ": " << strerror(-res);
-            }
-            else if (res == 0)
-            {
-                DLOG(INFO) << "Successfully deleted manifest file for table "
-                           << tbl_id;
-            }
-
+            LOG(ERROR) << "Failed to delete manifest file for table " << tbl_id
+                       << ": " << strerror(-res);
             KvError close_dir_err = CloseFile(std::move(dir_fd));
             if (close_dir_err != KvError::NoError)
             {
                 LOG(WARNING) << "Failed to close directory handle for table "
                              << tbl_id << ": " << ErrorString(close_dir_err);
             }
+            return ToKvError(res);
+        }
+        else if (res == 0)
+        {
+            DLOG(INFO) << "Successfully deleted manifest file for table "
+                       << tbl_id;
+        }
+
+        KvError close_dir_err = CloseFile(std::move(dir_fd));
+        if (close_dir_err != KvError::NoError)
+        {
+            LOG(WARNING) << "Failed to close directory handle for table "
+                         << tbl_id << ": " << ErrorString(close_dir_err);
         }
     }
     if (dir_err != KvError::NoError && dir_err != KvError::NotFound)
     {
         LOG(ERROR) << "Failed to open directory for table " << tbl_id
                    << " during cleanup: " << ErrorString(dir_err);
+        return dir_err;
     }
     KvError cleanup_err = TryCleanupLocalPartitionDir(tbl_id);
     if (cleanup_err != KvError::NoError)
     {
         LOG(WARNING) << "Failed to clean partition directory for table "
                      << tbl_id << ": " << ErrorString(cleanup_err);
+        return cleanup_err;
     }
+    return KvError::NoError;
 }
 
 KvError ToKvError(int err_no)
@@ -1179,19 +1179,10 @@ std::pair<IouringMgr::LruFD::Ref, KvError> IouringMgr::OpenOrCreateFD(
     // Avoid multiple coroutines from concurrently opening or closing the same
     // file duplicately.
     lru_fd.Get()->mu_.Lock();
-    DLOG(INFO) << "OpenOrCreateFD enter, tbl=" << tbl_id
-               << " file_id=" << file_id << " branch_name=" << branch_name
-               << " term=" << term << " create=" << create
-               << " reg_idx=" << lru_fd.Get()->reg_idx_
-               << " fd=" << lru_fd.Get()->fd_
-               << " cached_branch=" << lru_fd.Get()->branch_name_
-               << " cached_term=" << lru_fd.Get()->term_;
     if (file_id == LruFD::kDirectory)
     {
         if (lru_fd.Get()->fd_ != LruFD::FdEmpty)
         {
-            DLOG(INFO) << "OpenOrCreateFD cache hit (directory), tbl=" << tbl_id
-                       << " file_id=" << file_id;
             lru_fd.Get()->mu_.Unlock();
             return {std::move(lru_fd), KvError::NoError};
         }
@@ -1236,8 +1227,6 @@ std::pair<IouringMgr::LruFD::Ref, KvError> IouringMgr::OpenOrCreateFD(
             {
                 // Mismatch detected, close and reopen with correct
                 // term/branch.
-                DLOG(INFO) << "OpenOrCreateFD closing stale FD, tbl=" << tbl_id
-                           << " file_id=" << file_id;
                 int old_idx = lru_fd.Get()->reg_idx_;
                 int res = CloseDirect(old_idx);
                 if (res < 0)
@@ -1251,8 +1240,6 @@ std::pair<IouringMgr::LruFD::Ref, KvError> IouringMgr::OpenOrCreateFD(
             else
             {
                 // No mismatch, use cached FD.
-                DLOG(INFO) << "OpenOrCreateFD cache hit (no mismatch), tbl="
-                           << tbl_id << " file_id=" << file_id;
                 lru_fd.Get()->mu_.Unlock();
                 return {std::move(lru_fd), KvError::NoError};
             }
@@ -1260,8 +1247,6 @@ std::pair<IouringMgr::LruFD::Ref, KvError> IouringMgr::OpenOrCreateFD(
         else
         {
             // Local mode or directory, use cached FD.
-            DLOG(INFO) << "OpenOrCreateFD cache hit (local mode), tbl="
-                       << tbl_id << " file_id=" << file_id;
             lru_fd.Get()->mu_.Unlock();
             return {std::move(lru_fd), KvError::NoError};
         }
@@ -1356,9 +1341,6 @@ bool IouringMgr::GetBranchNameAndTerm(const TableIdent &tbl_id,
     const auto &mapping = it_term_tbl->second;
     bool res =
         ::eloqstore::GetBranchNameAndTerm(mapping, file_id, branch_name, term);
-    DLOG(INFO) << "GetBranchNameAndTerm, tbl_id=" << tbl_id
-               << " file_id=" << file_id << " branch_name=" << branch_name
-               << " term=" << term;
     return res;
 }
 
@@ -1381,9 +1363,6 @@ void IouringMgr::SetBranchFileIdTerm(const TableIdent &tbl_id,
     {
         mapping.push_back({std::string(branch_name), term, file_id});
     }
-    DLOG(INFO) << "SetBranchNameAndTerm, tbl_id=" << tbl_id
-               << "file_id=" << file_id << " branch_name=" << branch_name
-               << " term=" << term;
 }
 
 void IouringMgr::SetBranchFileMapping(const TableIdent &tbl_id,
@@ -3010,10 +2989,6 @@ void CloudStoreMgr::OnFileRangeWritePrepared(const TableIdent &tbl_id,
         (file_id == LruFD::kManifest)
             ? BranchManifestFileName(branch_name, term)
             : BranchDataFileName(file_id, branch_name, term);
-    DLOG(INFO) << "OnFileRangeWritePrepared, tbl=" << tbl_id
-               << " file_id=" << file_id << " branch_name=" << branch_name
-               << " term=" << term << " offset=" << offset
-               << " bytes=" << data.size() << " filename=" << filename;
     WriteTask::UploadState &state = owner->MutableUploadState();
     if (state.invalid)
     {
@@ -4429,7 +4404,81 @@ std::tuple<uint64_t, std::string, KvError> CloudStoreMgr::ReadTermFile(
     return {term, download_task.etag_, KvError::NoError};
 }
 
-void CloudStoreMgr::RequestGcLocalCleanup(
+KvError CloudStoreMgr::CleanupLocalPartitionFiles(const TableIdent &tbl_id)
+{
+    namespace fs = std::filesystem;
+
+    const fs::path table_path =
+        tbl_id.StorePath(options_->store_path, options_->store_path_lut);
+    std::error_code ec;
+    if (!fs::exists(table_path, ec))
+    {
+        return ec ? ToKvError(-ec.value()) : KvError::NoError;
+    }
+
+    std::vector<std::string> cleanup_targets;
+    for (fs::directory_iterator it(table_path, ec), end; it != end;
+         it.increment(ec))
+    {
+        if (ec)
+        {
+            break;
+        }
+        if (!it->is_regular_file())
+        {
+            continue;
+        }
+
+        const std::string filename = it->path().filename().string();
+        auto [prefix, suffix] = ParseFileName(filename);
+        static_cast<void>(suffix);
+        if (prefix == FileNameData)
+        {
+            cleanup_targets.push_back(filename);
+        }
+    }
+
+    CHECK(shard != nullptr);
+    bool empty_mapping = false;
+    RootMetaMgr *root_meta_mgr = shard->IndexManager()->RootMetaManager();
+    auto *entry = root_meta_mgr->Find(tbl_id);
+    if (entry != nullptr)
+    {
+        RootMeta &meta = entry->meta_;
+        empty_mapping = meta.mapper_ != nullptr && meta.root_id_ == MaxPageId &&
+                        meta.ttl_root_id_ == MaxPageId &&
+                        meta.mapper_->MappingCount() == 0;
+    }
+
+    if (empty_mapping)
+    {
+        const std::string manifest_name =
+            BranchManifestFileName(GetActiveBranch(), ProcessTerm());
+        const fs::path manifest_path = table_path / manifest_name;
+        if (fs::exists(manifest_path, ec) && !ec)
+        {
+            FileKey manifest_key{tbl_id, manifest_name};
+            if (!closed_files_.contains(manifest_key))
+            {
+                EnqueClosedFile(manifest_key);
+            }
+            cleanup_targets.push_back(manifest_name);
+        }
+    }
+
+    if (!cleanup_targets.empty())
+    {
+        ScheduleLocalFileCleanup(tbl_id, cleanup_targets);
+    }
+    else
+    {
+        return TryCleanupLocalPartitionDir(tbl_id);
+    }
+
+    return KvError::NoError;
+}
+
+void CloudStoreMgr::ScheduleLocalFileCleanup(
     const TableIdent &tbl_id, const std::vector<std::string> &filenames)
 {
     bool queued = false;
@@ -4564,9 +4613,13 @@ KvError CloudStoreMgr::SwitchManifest(const TableIdent &tbl_id,
     return KvError::NoError;
 }
 
-void CloudStoreMgr::CleanManifest(const TableIdent &tbl_id)
+KvError CloudStoreMgr::CleanManifest(const TableIdent &tbl_id)
 {
-    IouringMgr::CleanManifest(tbl_id);
+    KvError err = IouringMgr::CleanManifest(tbl_id);
+    if (err != KvError::NoError)
+    {
+        return err;
+    }
     (void) DequeClosedFile(FileKey(
         tbl_id, BranchManifestFileName(GetActiveBranch(), ProcessTerm())));
     if (!HasTrackedLocalFiles(tbl_id))
@@ -4576,8 +4629,10 @@ void CloudStoreMgr::CleanManifest(const TableIdent &tbl_id)
         {
             LOG(WARNING) << "Failed to clean partition directory for table "
                          << tbl_id << ": " << ErrorString(cleanup_err);
+            return cleanup_err;
         }
     }
+    return KvError::NoError;
 }
 
 KvError CloudStoreMgr::CreateArchive(const TableIdent &tbl_id,
@@ -5274,8 +5329,7 @@ int CloudStoreMgr::ReserveCacheSpace(size_t size)
             LOG(WARNING) << "Cannot reserve " << size
                          << " bytes: used=" << used_local_space_
                          << " limit=" << shard_local_space_limit_
-                         << " no evictable files"
-                         << " task=" << current_task;
+                         << " no evictable files" << " task=" << current_task;
             return -ENOSPC;
         }
 
@@ -6336,8 +6390,9 @@ KvError MemStoreMgr::AbortWrite(const TableIdent &tbl_id)
     return KvError::NoError;
 }
 
-void MemStoreMgr::CleanManifest(const TableIdent &tbl_id)
+KvError MemStoreMgr::CleanManifest(const TableIdent &tbl_id)
 {
+    return KvError::NoError;
 }
 
 KvError MemStoreMgr::AppendManifest(const TableIdent &tbl_id,

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -566,7 +566,7 @@ KvError IouringMgr::ReadPages(const TableIdent &tbl_id,
             : BaseReq(task),
               offset_(offset),
               fd_ref_(std::move(fd)),
-              page_(true){};
+              page_(true) {};
 
         bool done_{false};
         uint32_t offset_;
@@ -1714,7 +1714,7 @@ KvError IouringMgr::FdatasyncFiles(const TableIdent &tbl_id,
     struct FsyncReq : BaseReq
     {
         FsyncReq(KvTask *task, LruFD::Ref fd)
-            : BaseReq(task), fd_ref_(std::move(fd)){};
+            : BaseReq(task), fd_ref_(std::move(fd)) {};
         LruFD::Ref fd_ref_;
     };
 
@@ -1771,7 +1771,7 @@ KvError IouringMgr::CloseFiles(std::span<LruFD::Ref> fds)
     struct CloseReq : BaseReq
     {
         CloseReq(KvTask *task, LruFD::Ref fd)
-            : BaseReq(task), fd_ref_(std::move(fd)){};
+            : BaseReq(task), fd_ref_(std::move(fd)) {};
         LruFD::Ref fd_ref_;
         int reg_idx_{-1};
         int fd_{LruFD::FdEmpty};
@@ -4422,9 +4422,14 @@ KvError CloudStoreMgr::CleanupLocalPartitionFiles(const TableIdent &tbl_id)
     {
         if (ec)
         {
-            break;
+            return ToKvError(-ec.value());
         }
-        if (!it->is_regular_file())
+        const fs::file_status status = it->status(ec);
+        if (ec)
+        {
+            return ToKvError(-ec.value());
+        }
+        if (!fs::is_regular_file(status))
         {
             continue;
         }
@@ -6302,7 +6307,7 @@ void CloudStoreMgr::FileCleaner::Shutdown()
     coro_ = coro_.resume();
 }
 
-MemStoreMgr::MemStoreMgr(const KvOptions *opts) : AsyncIoManager(opts){};
+MemStoreMgr::MemStoreMgr(const KvOptions *opts) : AsyncIoManager(opts) {};
 
 KvError MemStoreMgr::Init(Shard *shard)
 {

--- a/src/eloq_store.cpp
+++ b/src/eloq_store.cpp
@@ -53,6 +53,62 @@ namespace
 {
 constexpr uint64_t kStorePathWeightGranularity = 1ULL << 20;  // 1 MiB
 constexpr size_t kMaxStorePathLutEntries = kDefaultStorePathLutEntries;
+
+KvError CollectLocalPartitions(const KvOptions &options,
+                               std::vector<TableIdent> &partitions)
+{
+    partitions.clear();
+    std::error_code ec;
+#ifndef NDEBUG
+    std::unordered_set<TableIdent> seen;
+#endif
+    for (const std::string &root_str : options.store_path)
+    {
+        const fs::path root(root_str);
+        fs::directory_iterator dir_it(root, ec);
+        if (ec)
+        {
+            return ToKvError(-ec.value());
+        }
+        fs::directory_iterator end;
+        for (; dir_it != end; dir_it.increment(ec))
+        {
+            if (ec)
+            {
+                return ToKvError(-ec.value());
+            }
+            const fs::directory_entry &entry = *dir_it;
+            bool is_dir = entry.is_directory(ec);
+            if (ec)
+            {
+                return ToKvError(-ec.value());
+            }
+            if (!is_dir)
+            {
+                continue;
+            }
+
+            TableIdent tbl_id = TableIdent::FromString(entry.path().filename());
+            if (!tbl_id.IsValid())
+            {
+                LOG(WARNING) << "unexpected partition " << entry.path();
+                continue;
+            }
+            if (options.partition_filter && !options.partition_filter(tbl_id))
+            {
+                continue;
+            }
+#ifndef NDEBUG
+            if (!seen.insert(tbl_id).second)
+            {
+                LOG(FATAL) << "Duplicated partition directory: " << tbl_id;
+            }
+#endif
+            partitions.emplace_back(std::move(tbl_id));
+        }
+    }
+    return KvError::NoError;
+}
 }  // namespace
 
 bool EloqStore::ValidateOptions(KvOptions &opts)
@@ -214,7 +270,7 @@ bool EloqStore::ValidateOptions(KvOptions &opts)
             if (remote_path.empty() || remote_path.front() != '/')
             {
                 LOG(ERROR) << "standby_master_store_paths must be "
-                           << "absolute paths";
+                           << "absolute paths, wrong path:" << remote_path;
                 return false;
             }
         }
@@ -1448,6 +1504,7 @@ void EloqStore::HandleGlobalReopenRequest(GlobalReopenRequest *req)
     req->reopen_reqs_.clear();
 
     std::vector<TableIdent> partitions;
+    std::unordered_set<TableIdent> remote_partitions;
     if (Mode() == StoreMode::StandbyReplica)
     {
         std::vector<std::string> names;
@@ -1482,57 +1539,33 @@ void EloqStore::HandleGlobalReopenRequest(GlobalReopenRequest *req)
             {
                 continue;
             }
+            remote_partitions.insert(tbl_id);
+            partitions.emplace_back(std::move(tbl_id));
+        }
+
+        std::vector<TableIdent> local_partitions;
+        KvError local_err = CollectLocalPartitions(options_, local_partitions);
+        if (local_err != KvError::NoError)
+        {
+            req->SetDone(local_err);
+            return;
+        }
+        for (TableIdent &tbl_id : local_partitions)
+        {
+            if (remote_partitions.contains(tbl_id))
+            {
+                continue;
+            }
             partitions.emplace_back(std::move(tbl_id));
         }
     }
     else
     {
-        std::error_code ec;
-        for (const fs::path root : options_.store_path)
+        KvError local_err = CollectLocalPartitions(options_, partitions);
+        if (local_err != KvError::NoError)
         {
-            const fs::path db_path(root);
-            fs::directory_iterator dir_it(db_path, ec);
-            if (ec)
-            {
-                req->SetDone(ToKvError(-ec.value()));
-                return;
-            }
-            fs::directory_iterator end;
-            for (; dir_it != end; dir_it.increment(ec))
-            {
-                if (ec)
-                {
-                    req->SetDone(ToKvError(-ec.value()));
-                    return;
-                }
-                const fs::directory_entry &ent = *dir_it;
-                const fs::path ent_path = ent.path();
-                bool is_dir = fs::is_directory(ent_path, ec);
-                if (ec)
-                {
-                    req->SetDone(ToKvError(-ec.value()));
-                    return;
-                }
-                if (!is_dir)
-                {
-                    continue;
-                }
-
-                TableIdent tbl_id = TableIdent::FromString(ent_path.filename());
-                if (tbl_id.tbl_name_.empty())
-                {
-                    LOG(WARNING) << "unexpected partition " << ent.path();
-                    continue;
-                }
-
-                if (options_.partition_filter &&
-                    !options_.partition_filter(tbl_id))
-                {
-                    continue;
-                }
-
-                partitions.emplace_back(std::move(tbl_id));
-            }
+            req->SetDone(local_err);
+            return;
         }
     }
 
@@ -1557,6 +1590,11 @@ void EloqStore::HandleGlobalReopenRequest(GlobalReopenRequest *req)
         if (!req->Tag().empty())
         {
             reopen_req->SetTag(req->Tag());
+        }
+        if (Mode() == StoreMode::StandbyReplica &&
+            !remote_partitions.contains(partition))
+        {
+            reopen_req->SetClean(true);
         }
         req->reopen_reqs_.push_back(std::move(reopen_req));
     }
@@ -2441,6 +2479,7 @@ void ReopenRequest::SetArgs(TableIdent tbl_id)
 {
     SetTableId(std::move(tbl_id));
     tag_.clear();
+    clean_ = false;
 }
 
 void DropTableRequest::SetArgs(std::string table_name)

--- a/src/file_gc.cpp
+++ b/src/file_gc.cpp
@@ -606,7 +606,7 @@ KvError AugmentRetainedFilesFromBranchManifests(
     assert(manifest_branch_names.size() == manifest_terms.size());
     assert(archive_files.size() == archive_branch_names.size());
 
-    bool is_cloud = !io_mgr->options_->cloud_store_path.empty();
+    bool is_cloud = eloq_store->Mode() == StoreMode::Cloud;
     CloudStoreMgr *cloud_mgr =
         is_cloud ? static_cast<CloudStoreMgr *>(io_mgr) : nullptr;
 
@@ -651,6 +651,14 @@ KvError AugmentRetainedFilesFromBranchManifests(
                          << filename << " for branch " << branch << " term "
                          << term << ", error=" << static_cast<int>(err);
             return err;
+        }
+        else
+        {
+            LOG(ERROR) << "AugmentRetainedFilesFromBranchManifests: manifest "
+                       << filename << " for branch " << branch << " term "
+                       << term
+                       << " not found during GC scan, skipping retained-file "
+                          "augmentation for this manifest";
         }
     }
 

--- a/src/file_gc.cpp
+++ b/src/file_gc.cpp
@@ -230,6 +230,75 @@ KvError ExecuteLocalGC(const TableIdent &tbl_id,
         return err;
     }
 
+    // If the partition is now empty except for the current manifest, clean the
+    // manifest as well so the local directory can be removed without waiting
+    // for later root-meta eviction.
+    local_files.clear();
+    err = ListLocalFiles(tbl_id, local_files, io_mgr);
+    if (err != KvError::NoError)
+    {
+        LOG(ERROR) << "ExecuteLocalGC: post-delete ListLocalFiles failed, "
+                   << "error=" << static_cast<int>(err);
+        return err;
+    }
+
+    archive_files.clear();
+    archive_tags.clear();
+    archive_branch_names.clear();
+    data_files.clear();
+    manifest_terms.clear();
+    manifest_branch_names.clear();
+    ClassifyFiles(local_files,
+                  archive_files,
+                  archive_tags,
+                  archive_branch_names,
+                  data_files,
+                  manifest_terms,
+                  manifest_branch_names);
+
+    if (data_files.empty() && archive_files.empty())
+    {
+        const StoreMode mode = eloq_store->Mode();
+        if (mode == StoreMode::Cloud)
+        {
+            auto *cloud_mgr = static_cast<CloudStoreMgr *>(io_mgr);
+            err = cloud_mgr->CleanupLocalPartitionFiles(tbl_id);
+            if (err != KvError::NoError)
+            {
+                LOG(ERROR)
+                    << "ExecuteLocalGC: CleanupLocalPartitionFiles failed, "
+                    << "error=" << static_cast<int>(err);
+                return err;
+            }
+        }
+        else
+        {
+            err = io_mgr->CleanManifest(tbl_id);
+            if (err != KvError::NoError)
+            {
+                LOG(ERROR) << "ExecuteLocalGC: CleanManifest failed, error="
+                           << static_cast<int>(err);
+                return err;
+            }
+
+            CHECK(shard != nullptr);
+            RootMetaMgr *root_meta_mgr =
+                shard->IndexManager()->RootMetaManager();
+            auto *entry = root_meta_mgr->Find(tbl_id);
+            if (entry != nullptr)
+            {
+                RootMeta &meta = entry->meta_;
+                if (meta.mapper_ != nullptr && meta.manifest_size_ != 0 &&
+                    meta.root_id_ == MaxPageId &&
+                    meta.ttl_root_id_ == MaxPageId &&
+                    meta.mapper_->MappingCount() == 0)
+                {
+                    meta.manifest_size_ = 0;
+                }
+            }
+        }
+    }
+
     /*
     // 4. delete old archives beyond num_retained_archives per branch.
     // NOTE: this step is intentionally AFTER DeleteUnreferencedLocalFiles so
@@ -561,24 +630,26 @@ KvError AugmentRetainedFilesFromBranchManifests(
             err = io_mgr->ReadFile(tbl_id, filename, buf);
         }
 
-        if (err != KvError::NoError)
+        if (err == KvError::NoError)
         {
-            LOG(WARNING)
-                << "AugmentRetainedFilesFromBranchManifests: failed to read "
-                   "manifest "
-                << filename << " for branch " << branch << " term " << term
-                << ", error=" << static_cast<int>(err);
-            return err;
+            err = ProcessOneManifest(filename,
+                                     term,
+                                     buf,
+                                     retained_files,
+                                     max_file_id_per_branch_term,
+                                     pages_per_file_shift);
+            if (err != KvError::NoError)
+            {
+                return err;
+            }
         }
-
-        err = ProcessOneManifest(filename,
-                                 term,
-                                 buf,
-                                 retained_files,
-                                 max_file_id_per_branch_term,
-                                 pages_per_file_shift);
-        if (err != KvError::NoError)
+        else if (err != KvError::NotFound)
         {
+            LOG(WARNING) << "AugmentRetainedFilesFromBranchManifests: "
+                            "failed to read "
+                            "manifest "
+                         << filename << " for branch " << branch << " term "
+                         << term << ", error=" << static_cast<int>(err);
             return err;
         }
     }
@@ -1134,7 +1205,7 @@ KvError ExecuteCloudGC(const TableIdent &tbl_id,
             tbl_id, deleted_filenames, cloud_mgr, local_cleanup_targets);
         if (!local_cleanup_targets.empty())
         {
-            cloud_mgr->RequestGcLocalCleanup(tbl_id, local_cleanup_targets);
+            cloud_mgr->ScheduleLocalFileCleanup(tbl_id, local_cleanup_targets);
         }
     }
 

--- a/src/file_gc.cpp
+++ b/src/file_gc.cpp
@@ -8,7 +8,6 @@
 #include <iterator>
 #include <memory>
 #include <optional>
-#include <random>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -461,29 +460,10 @@ void ClassifyFiles(const std::vector<std::string> &files,
     }
 }
 
-// Generate a random string of given length
-static std::string GenerateRandomString(size_t length)
-{
-    static const char alphanum[] =
-        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    static thread_local std::mt19937 rng{std::random_device{}()};
-    static thread_local std::uniform_int_distribution<size_t> dist(
-        0, sizeof(alphanum) - 2);
-
-    std::string result;
-    result.reserve(length);
-    for (size_t i = 0; i < length; ++i)
-    {
-        result += alphanum[dist(rng)];
-    }
-    return result;
-}
-
 KvError ReadCloudFile(const TableIdent &tbl_id,
                       const std::string &cloud_file,
                       DirectIoBuffer &content,
-                      CloudStoreMgr *cloud_mgr,
-                      const KvOptions *options)
+                      CloudStoreMgr *cloud_mgr)
 {
     KvTask *current_task = ThdTask();
 
@@ -503,44 +483,7 @@ KvError ReadCloudFile(const TableIdent &tbl_id,
                    << ", error: " << static_cast<int>(download_task.error_);
         return download_task.error_;
     }
-
-    // Generate a unique temporary filename to avoid conflicts with existing
-    // files
-    std::string temp_filename = cloud_file + ".tmp_" + GenerateRandomString(8);
-    fs::path temp_local_path =
-        tbl_id.StorePath(options->store_path, options->store_path_lut) /
-        temp_filename;
-
-    uint64_t flags = O_WRONLY | O_CREAT | O_DIRECT | O_NOATIME | O_TRUNC;
-    KvError write_err = cloud_mgr->WriteFile(
-        tbl_id, temp_filename, download_task.response_data_, flags);
-    cloud_mgr->RecycleBuffer(std::move(download_task.response_data_));
-    if (write_err != KvError::NoError)
-    {
-        LOG(ERROR) << "Failed to persist cloud file to temp path: "
-                   << temp_local_path
-                   << ", error: " << static_cast<int>(write_err);
-        return write_err;
-    }
-
-    // Read the temp file and then delete it
-    KvError err = cloud_mgr->ReadFile(tbl_id, temp_filename, content);
-    if (err != KvError::NoError)
-    {
-        LOG(ERROR) << "Failed to read temp file: " << temp_local_path
-                   << ", error: " << static_cast<int>(err);
-        // Try to clean up the temp file even if read failed
-        cloud_mgr->DeleteFiles({temp_local_path.string()});
-        return err;
-    }
-
-    // Delete the temp file
-    KvError delete_err = cloud_mgr->DeleteFiles({temp_local_path.string()});
-    if (delete_err != KvError::NoError)
-    {
-        LOG(WARNING) << "Failed to delete temp file: " << temp_local_path
-                     << ", error: " << static_cast<int>(delete_err);
-    }
+    content = std::move(download_task.response_data_);
 
     DLOG(INFO) << "Successfully downloaded and read cloud file: " << cloud_file;
     return KvError::NoError;
@@ -622,8 +565,7 @@ KvError AugmentRetainedFilesFromBranchManifests(
 
         if (is_cloud)
         {
-            err = ReadCloudFile(
-                tbl_id, filename, buf, cloud_mgr, cloud_mgr->options_);
+            err = ReadCloudFile(tbl_id, filename, buf, cloud_mgr);
         }
         else
         {
@@ -674,8 +616,7 @@ KvError AugmentRetainedFilesFromBranchManifests(
 
         if (is_cloud)
         {
-            err = ReadCloudFile(
-                tbl_id, filename, buf, cloud_mgr, cloud_mgr->options_);
+            err = ReadCloudFile(tbl_id, filename, buf, cloud_mgr);
         }
         else
         {

--- a/src/standby_service.cpp
+++ b/src/standby_service.cpp
@@ -1001,11 +1001,12 @@ void StandbyService::HandleExitedChild(std::list<InflightJob>::iterator it,
 {
     InflightJob &job = *it;
     const Step step = job.step;
+    const std::string log_target = job.log_target;
     ReleaseProcessHandles(&job);
 
     if (step == Step::RsyncData)
     {
-        KvError result = InterpretRsyncStatus(status, job.log_target);
+        KvError result = InterpretRsyncStatus(status, log_target);
         if (result != KvError::NoError)
         {
             FinishInflightJob(it, result);
@@ -1053,7 +1054,7 @@ void StandbyService::HandleExitedChild(std::list<InflightJob>::iterator it,
 
     if (step == Step::RsyncManifest)
     {
-        KvError result = InterpretRsyncStatus(status, job.log_target);
+        KvError result = InterpretRsyncStatus(status, log_target);
         if (result != KvError::NoError)
         {
             FinishInflightJob(it, result);
@@ -1076,7 +1077,7 @@ void StandbyService::HandleExitedChild(std::list<InflightJob>::iterator it,
 
     if (step == Step::ListPartitions)
     {
-        KvError result = InterpretCommandStatus(status, job.log_target);
+        KvError result = InterpretCommandStatus(status, log_target);
         if (result != KvError::NoError)
         {
             LOG(ERROR) << "StandbyService: failed to list partitions under "

--- a/src/storage/index_page_manager.cpp
+++ b/src/storage/index_page_manager.cpp
@@ -409,9 +409,6 @@ KvError IndexPageManager::InstallEmptySnapshot(const TableIdent &tbl_ident,
     static_cast<void>(inserted);
     RootMeta &meta = entry->meta_;
     auto mapper = std::make_unique<PageMapper>(this, &entry->tbl_id_);
-    MappingSnapshot *mapping = mapper->GetMapping();
-    auto it = meta.mapping_snapshots_.insert(mapping);
-    CHECK(it.second);
 
     cow_meta = CowRootMeta();
     cow_meta.root_id_ = MaxPageId;
@@ -439,10 +436,9 @@ KvError IndexPageManager::InstallEmptySnapshot(const TableIdent &tbl_ident,
     // state for reopen/cleanup.
     auto *io_mgr = static_cast<IouringMgr *>(IoMgr());
     KvError err = io_mgr->IouringMgr::SwitchManifest(tbl_ident, snapshot);
-    if (err != KvError::NoError)
-    {
-        return err;
-    }
+    CHECK_KV_ERR(err);
+    auto it = meta.mapping_snapshots_.insert(cow_meta.mapper_->GetMapping());
+    CHECK(it.second);
     cow_meta.manifest_size_ = snapshot.size();
 
     UpdateRoot(tbl_ident, std::move(cow_meta));

--- a/src/storage/index_page_manager.cpp
+++ b/src/storage/index_page_manager.cpp
@@ -402,6 +402,54 @@ void IndexPageManager::UpdateRoot(const TableIdent &tbl_ident,
     root_meta_mgr_.EvictIfNeeded();
 }
 
+KvError IndexPageManager::InstallEmptySnapshot(const TableIdent &tbl_ident,
+                                               CowRootMeta &cow_meta)
+{
+    auto [entry, inserted] = RootMetaManager()->GetOrCreate(tbl_ident);
+    static_cast<void>(inserted);
+    RootMeta &meta = entry->meta_;
+    auto mapper = std::make_unique<PageMapper>(this, &entry->tbl_id_);
+    MappingSnapshot *mapping = mapper->GetMapping();
+    auto it = meta.mapping_snapshots_.insert(mapping);
+    CHECK(it.second);
+
+    cow_meta = CowRootMeta();
+    cow_meta.root_id_ = MaxPageId;
+    cow_meta.ttl_root_id_ = MaxPageId;
+    cow_meta.mapper_ = std::move(mapper);
+    cow_meta.next_expire_ts_ = 0;
+    cow_meta.compression_ = std::make_shared<compression::DictCompression>();
+
+    BranchManifestMetadata branch_metadata;
+    branch_metadata.branch_name = IoMgr()->GetActiveBranch();
+    branch_metadata.term = IoMgr()->ProcessTerm();
+    branch_metadata.file_ranges = {};
+
+    ManifestBuilder manifest_builder;
+    FilePageId max_fp_id = cow_meta.mapper_->FilePgAllocator()->MaxFilePageId();
+    std::string_view snapshot =
+        manifest_builder.Snapshot(cow_meta.root_id_,
+                                  cow_meta.ttl_root_id_,
+                                  cow_meta.mapper_->GetMapping(),
+                                  max_fp_id,
+                                  {},
+                                  branch_metadata);
+    // Use the base local manifest rewrite path here. The cloud override also
+    // uploads the manifest, but an empty snapshot should only replace local
+    // state for reopen/cleanup.
+    auto *io_mgr = static_cast<IouringMgr *>(IoMgr());
+    KvError err = io_mgr->IouringMgr::SwitchManifest(tbl_ident, snapshot);
+    if (err != KvError::NoError)
+    {
+        return err;
+    }
+    cow_meta.manifest_size_ = snapshot.size();
+
+    UpdateRoot(tbl_ident, std::move(cow_meta));
+    IoMgr()->SetBranchFileMapping(entry->tbl_id_, {});
+    return KvError::NoError;
+}
+
 KvError IndexPageManager::InstallExternalSnapshot(const TableIdent &tbl_ident,
                                                   CowRootMeta &cow_meta,
                                                   std::string_view reopen_tag)
@@ -470,6 +518,12 @@ KvError IndexPageManager::InstallExternalSnapshot(const TableIdent &tbl_ident,
     }
     if (err != KvError::NoError)
     {
+        if (err == KvError::NotFound)
+        {
+            LOG(INFO) << "InstallExternalSnapshot missing remote state for "
+                      << "table " << tbl_ident << ", tag " << reopen_tag;
+            return InstallEmptySnapshot(tbl_ident, cow_meta);
+        }
         LOG(ERROR) << "InstallExternalSnapshot RefreshManifest failed, table "
                    << tbl_ident << ", mode " << static_cast<int>(mode)
                    << ", tag " << reopen_tag << ", error "

--- a/src/storage/root_meta.cpp
+++ b/src/storage/root_meta.cpp
@@ -294,7 +294,12 @@ bool RootMetaMgr::EvictRootForCache(Entry *entry)
         meta.locked_ = true;
         LOG(INFO) << "Evicting manifest for table " << tbl_id << " size "
                   << meta.manifest_size_;
-        owner_->IoMgr()->CleanManifest(tbl_id);
+        KvError err = owner_->IoMgr()->CleanManifest(tbl_id);
+        if (err != KvError::NoError)
+        {
+            LOG(WARNING) << "Failed to clean manifest for table " << tbl_id
+                         << ": " << ErrorString(err);
+        }
         meta.waiting_.WakeAll();
     }
 

--- a/src/storage/shard.cpp
+++ b/src/storage/shard.cpp
@@ -524,8 +524,6 @@ bool Shard::ProcessReq(KvRequest *req)
     {
         ListStandbyPartitionTask *task =
             task_mgr_.GetListStandbyPartitionTask();
-        DLOG(INFO) << "Shard::ProcessReq ListStandbyPartition start, shard_id="
-                   << shard_id_ << ", req=" << req << ", task=" << task;
         auto lbd = [req]() -> KvError
         {
             StandbyService *standby = shard->store_->GetStandbyService();
@@ -536,18 +534,10 @@ bool Shard::ProcessReq(KvRequest *req)
             auto *list_req = static_cast<ListStandbyPartitionRequest *>(req);
             KvTask *current_task = ThdTask();
             CHECK(current_task != nullptr);
-            DLOG(INFO) << "Shard::ProcessReq ListStandbyPartition enqueue, req="
-                       << req << ", task=" << current_task;
             KvError enqueue_err =
                 standby->ListRemotePartitions(list_req->GetPartitions());
-            if (enqueue_err != KvError::NoError)
-            {
-                return enqueue_err;
-            }
+            CHECK_KV_ERR(enqueue_err);
             current_task->WaitIo();
-            DLOG(INFO) << "Shard::ProcessReq ListStandbyPartition done, req="
-                       << req << ", task=" << current_task
-                       << ", io_res=" << current_task->io_res_;
             return static_cast<KvError>(current_task->io_res_);
         };
         StartTask(task, req, lbd);

--- a/src/tasks/reopen_task.cpp
+++ b/src/tasks/reopen_task.cpp
@@ -16,7 +16,10 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
     CHECK(request_ != nullptr);
     StoreMode mode = shard->store_->Mode();
     if (mode == StoreMode::Local)
+    {
+        request_ = nullptr;
         return KvError::InvalidArgs;
+    }
     StandbyService *standby_service = nullptr;
     std::string tag;
     if (mode == StoreMode::StandbyReplica)
@@ -79,6 +82,7 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
                    << " InstallExternalSnapshot failed, tag " << request_->Tag()
                    << ", mode " << static_cast<int>(mode) << ", error "
                    << static_cast<uint32_t>(err);
+        request_ = nullptr;
         return err;
     }
     if (mode == StoreMode::Cloud && Options()->prewarm_cloud_cache)

--- a/src/tasks/reopen_task.cpp
+++ b/src/tasks/reopen_task.cpp
@@ -15,6 +15,8 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
 {
     CHECK(request_ != nullptr);
     StoreMode mode = shard->store_->Mode();
+    if (mode == StoreMode::Local)
+        return KvError::InvalidArgs;
     StandbyService *standby_service = nullptr;
     std::string tag;
     if (mode == StoreMode::StandbyReplica)
@@ -35,56 +37,79 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
             request_ = nullptr;
             return KvError::InvalidArgs;
         }
-        KvTask *current_task = ThdTask();
-        CHECK(current_task != nullptr);
-        KvError enqueue_err = standby_service->RsyncPartition(tbl_id, tag);
-        if (enqueue_err != KvError::NoError)
+        if (!request_->Clean())
         {
-            LOG(ERROR) << "Reopen " << tbl_id << " rsync enqueue failed, tag "
-                       << tag << ", error "
-                       << static_cast<uint32_t>(enqueue_err);
-            request_ = nullptr;
-            return enqueue_err;
-        }
-        current_task->WaitIo();
-        KvError sync_err = static_cast<KvError>(current_task->io_res_);
-        if (sync_err != KvError::NoError)
-        {
-            LOG(ERROR) << "Reopen " << tbl_id << " rsync failed, tag " << tag
-                       << ", error " << static_cast<uint32_t>(sync_err);
-            request_ = nullptr;
-            return sync_err;
+            KvTask *current_task = ThdTask();
+            CHECK(current_task != nullptr);
+            KvError enqueue_err = standby_service->RsyncPartition(tbl_id, tag);
+            if (enqueue_err != KvError::NoError)
+            {
+                LOG(ERROR) << "Reopen " << tbl_id
+                           << " rsync enqueue failed, tag " << tag << ", error "
+                           << static_cast<uint32_t>(enqueue_err);
+                request_ = nullptr;
+                return enqueue_err;
+            }
+            current_task->WaitIo();
+            KvError sync_err = static_cast<KvError>(current_task->io_res_);
+            if (sync_err != KvError::NoError && sync_err != KvError::NotFound)
+            {
+                LOG(ERROR) << "Reopen " << tbl_id << " rsync failed, tag "
+                           << tag << ", error "
+                           << static_cast<uint32_t>(sync_err);
+                request_ = nullptr;
+                return sync_err;
+            }
         }
     }
 
-    KvError err = shard->IndexManager()->InstallExternalSnapshot(
-        tbl_id, cow_meta_, request_->Tag());
+    KvError err = KvError::NoError;
+    if (request_->Clean())
+    {
+        err = shard->IndexManager()->InstallEmptySnapshot(tbl_id, cow_meta_);
+    }
+    else
+    {
+        err = shard->IndexManager()->InstallExternalSnapshot(
+            tbl_id, cow_meta_, request_->Tag());
+    }
     if (err != KvError::NoError)
     {
         LOG(ERROR) << "Reopen " << tbl_id
                    << " InstallExternalSnapshot failed, tag " << request_->Tag()
                    << ", mode " << static_cast<int>(mode) << ", error "
                    << static_cast<uint32_t>(err);
+        return err;
     }
-    if (err == KvError::NoError && mode != StoreMode::Local)
+    if (mode == StoreMode::Cloud && Options()->prewarm_cloud_cache)
     {
-        if (mode == StoreMode::Cloud && Options()->prewarm_cloud_cache)
-        {
-            CHECK(shard->store_ != nullptr);
-            PrewarmService *prewarm_service =
-                shard->store_->GetPrewarmService();
-            CHECK(prewarm_service != nullptr);
-            prewarm_service->Prewarm(tbl_id);
-        }
+        CHECK(shard->store_ != nullptr);
+        PrewarmService *prewarm_service = shard->store_->GetPrewarmService();
+        CHECK(prewarm_service != nullptr);
+        prewarm_service->Prewarm(tbl_id);
+    }
 
-        if (!shard->HasPendingLocalGc(tbl_id))
+    const bool empty_snapshot =
+        cow_meta_.root_id_ == MaxPageId && cow_meta_.ttl_root_id_ == MaxPageId;
+    if (mode == StoreMode::Cloud && empty_snapshot)
+    {
+        auto *cloud_mgr = static_cast<CloudStoreMgr *>(shard->IoManager());
+        err = cloud_mgr->CleanupLocalPartitionFiles(tbl_id);
+        if (err != KvError::NoError)
         {
-            shard->AddPendingLocalGc(tbl_id);
+            LOG(ERROR) << "Reopen " << tbl_id
+                       << " failed to cleanup local partition files, tag "
+                       << request_->Tag() << ", error "
+                       << static_cast<uint32_t>(err);
+            request_ = nullptr;
+            return err;
         }
+    }
+    else if (!shard->HasPendingLocalGc(tbl_id))
+    {
+        shard->AddPendingLocalGc(tbl_id);
     }
     request_ = nullptr;
-    DLOG(INFO) << "Reopen " << tbl_id << " finish, error "
-               << static_cast<uint32_t>(err);
     return err;
 }
 

--- a/tests/branch_operations.cpp
+++ b/tests/branch_operations.cpp
@@ -1215,8 +1215,7 @@ TEST_CASE("delete branch in cloud mode removes all cloud objects",
 //     are all gone from cloud storage.
 // ---------------------------------------------------------------------------
 TEST_CASE(
-    "delete branch removes all term manifests end-to-end across real Raft "
-    "terms",
+    "delete branch removes all term manifests end-to-end across real terms",
     "[branch][cloud]")
 {
     // Phase 1: clean slate.

--- a/tests/gc.cpp
+++ b/tests/gc.cpp
@@ -146,7 +146,8 @@ bool WaitForCondition(std::chrono::milliseconds timeout,
 }
 }  // namespace
 
-TEST_CASE("local mode truncate preserves current manifest", "[gc][local]")
+TEST_CASE("local mode truncate removes local partition directory",
+          "[gc][local]")
 {
     CleanupStore(local_gc_opts);
 
@@ -164,75 +165,33 @@ TEST_CASE("local mode truncate preserves current manifest", "[gc][local]")
     REQUIRE(WaitForCondition(
         3s,
         20ms,
-        [&]()
-        {
-            std::vector<std::string> files =
-                ListLocalPartitionFiles(local_gc_opts, tbl_id);
-            if (files.empty())
-            {
-                return false;
-            }
-            return files.size() == 1 &&
-                   files[0] == eloqstore::BranchManifestFileName(
-                                   eloqstore::MainBranchName, 0);
-        }));
+        [&]() { return !CheckLocalPartitionExists(local_gc_opts, tbl_id); }));
 
     store->Stop();
     CleanupStore(local_gc_opts);
 }
 
-TEST_CASE("local mode clean manifest removes empty partition directory",
+TEST_CASE("local mode truncate removes local partition directory after wait",
           "[gc][local]")
 {
-    eloqstore::KvOptions opts = local_gc_opts;
-    opts.num_threads = 1;
-    opts.root_meta_cache_size = 5000;
-    opts.init_page_count = 8;
-    opts.data_page_size = 4096;
+    CleanupStore(local_gc_opts);
 
-    CleanupStore(opts);
-
-    eloqstore::EloqStore *store = InitStore(opts);
-    eloqstore::TableIdent tbl_id = {"gc_delete_all", 1};
+    eloqstore::EloqStore *store = InitStore(local_gc_opts);
+    eloqstore::TableIdent tbl_id = {"gc_local_dir_cleanup", 1};
     MapVerifier tester(tbl_id, store, false);
-    tester.SetValueSize(256);
+    tester.SetValueSize(1000);
 
-    tester.Upsert(0, 200);
+    tester.Upsert(0, 100);
     tester.Validate();
-    REQUIRE(CheckLocalPartitionExists(opts, tbl_id));
+    REQUIRE(CheckLocalPartitionExists(local_gc_opts, tbl_id));
 
     tester.Truncate(0, true);
+    WaitForGC(2);
 
-    REQUIRE(WaitForCondition(3s,
-                             20ms,
-                             [&]()
-                             {
-                                 std::vector<std::string> files =
-                                     ListLocalPartitionFiles(opts, tbl_id);
-                                 return files.size() == 1 &&
-                                        files[0] ==
-                                            eloqstore::BranchManifestFileName(
-                                                eloqstore::MainBranchName, 0);
-                             }));
-
-    std::vector<std::unique_ptr<MapVerifier>> evictors;
-    for (uint32_t pid = 2; pid < 12; ++pid)
-    {
-        auto verifier = std::make_unique<MapVerifier>(
-            eloqstore::TableIdent{"gc_evict", pid}, store, false);
-        verifier->SetAutoClean(false);
-        verifier->SetValueSize(256);
-        verifier->Upsert(0, 200);
-        verifier->Read(0);
-        verifier->Read(1);
-        evictors.emplace_back(std::move(verifier));
-    }
-
-    REQUIRE(WaitForCondition(
-        5s, 20ms, [&]() { return !CheckLocalPartitionExists(opts, tbl_id); }));
+    REQUIRE_FALSE(CheckLocalPartitionExists(local_gc_opts, tbl_id));
 
     store->Stop();
-    CleanupStore(opts);
+    CleanupStore(local_gc_opts);
 }
 
 TEST_CASE("cloud mode truncate remote directory cleanup", "[gc][cloud]")
@@ -260,6 +219,32 @@ TEST_CASE("cloud mode truncate remote directory cleanup", "[gc][cloud]")
 
     // Verify cloud partition directory is removed
     REQUIRE_FALSE(CheckCloudPartitionExists(options, tbl_id));
+}
+
+TEST_CASE("cloud mode truncate removes local partition directory after wait",
+          "[gc][cloud]")
+{
+    CleanupStore(cloud_gc_opts);
+
+    eloqstore::KvOptions options = cloud_gc_opts;
+    options.fd_limit += utils::CountUsedFD();
+
+    eloqstore::EloqStore *store = InitStore(options);
+    eloqstore::TableIdent tbl_id = {"gc_cloud_local_dir_cleanup", 1};
+    MapVerifier tester(tbl_id, store, false);
+    tester.SetValueSize(1000);
+
+    tester.Upsert(0, 100);
+    tester.Validate();
+    REQUIRE(CheckLocalPartitionExists(options, tbl_id));
+
+    tester.Truncate(0, true);
+    WaitForGC(2);
+
+    REQUIRE_FALSE(CheckLocalPartitionExists(options, tbl_id));
+
+    store->Stop();
+    CleanupStore(options);
 }
 
 TEST_CASE("cloud mode delete all data remote cleanup", "[gc][cloud]")

--- a/tests/standby.cpp
+++ b/tests/standby.cpp
@@ -37,7 +37,251 @@ bool WaitForCondition(std::chrono::milliseconds timeout,
     }
     return pred();
 }
+
+void UpsertRange(eloqstore::EloqStore &store,
+                 const eloqstore::TableIdent &tbl_id,
+                 uint64_t begin,
+                 uint64_t end)
+{
+    std::vector<eloqstore::WriteDataEntry> entries;
+    for (uint64_t i = begin; i < end; ++i)
+    {
+        entries.emplace_back(Key(i), Value(i), 0, eloqstore::WriteOp::Upsert);
+    }
+    eloqstore::BatchWriteRequest req;
+    req.SetArgs(tbl_id, std::move(entries));
+    store.ExecSync(&req);
+    REQUIRE(req.Error() == eloqstore::KvError::NoError);
+}
+
+void DeleteRange(eloqstore::EloqStore &store,
+                 const eloqstore::TableIdent &tbl_id,
+                 uint64_t begin,
+                 uint64_t end)
+{
+    std::vector<eloqstore::WriteDataEntry> entries;
+    for (uint64_t i = begin; i < end; ++i)
+    {
+        entries.emplace_back(Key(i), "", 0, eloqstore::WriteOp::Delete);
+    }
+    eloqstore::BatchWriteRequest req;
+    req.SetArgs(tbl_id, std::move(entries));
+    store.ExecSync(&req);
+    REQUIRE(req.Error() == eloqstore::KvError::NoError);
+}
+
+void VerifyRange(eloqstore::EloqStore &store,
+                 const eloqstore::TableIdent &tbl_id,
+                 uint64_t begin,
+                 uint64_t end,
+                 bool expect_exists)
+{
+    for (uint64_t i = begin; i < end; ++i)
+    {
+        eloqstore::ReadRequest req;
+        req.SetArgs(tbl_id, Key(i));
+        store.ExecSync(&req);
+        if (expect_exists)
+        {
+            REQUIRE(req.Error() == eloqstore::KvError::NoError);
+            REQUIRE(req.value_ == Value(i));
+        }
+        else
+        {
+            REQUIRE(req.Error() == eloqstore::KvError::NotFound);
+        }
+    }
+}
 }  // namespace
+
+TEST_CASE("standby reopen a partition with nonexistent dir", "[standby]")
+{
+    fs::path dir = fs::temp_directory_path() / fs::path("standby-test");
+    fs::path remote_master_dir = dir / "remote-master";
+    fs::path local_dir = dir / "local";
+    fs::remove_all(dir);
+    fs::create_directories(local_dir);
+    fs::create_directories(remote_master_dir);
+
+    eloqstore::KvOptions opts;
+    opts.store_path = {local_dir.string()};
+    opts.enable_local_standby = true;
+    opts.standby_master_store_paths = {};
+    opts.pages_per_file_shift = 0;
+
+    eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+
+    eloqstore::EloqStore store(opts);
+    REQUIRE(store.Start("main", 1) == eloqstore::KvError::NoError);
+    UpsertRange(store, tbl_id, 0, 5000);
+    VerifyRange(store, tbl_id, 0, 5000, true);
+    store.Stop();
+
+    opts.standby_master_addr = "local";
+    opts.standby_master_store_paths = {remote_master_dir.string()};
+    eloqstore::EloqStore standby(opts);
+    REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+    eloqstore::GlobalReopenRequest reopen_req;
+    reopen_req.SetTag(std::to_string(1001));
+    standby.ExecSync(&reopen_req);
+    REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
+
+    VerifyRange(standby, tbl_id, 0, 5000, false);
+
+    standby.Stop();
+
+    fs::remove_all(dir);
+}
+
+TEST_CASE("standby reopen a partition with empty dir", "[standby]")
+{
+    fs::path dir = fs::temp_directory_path() / fs::path("standby-test");
+    fs::path remote_master_dir = dir / "remote-master";
+    fs::path local_dir = dir / "local";
+
+    eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+
+    fs::remove_all(dir);
+    fs::create_directories(remote_master_dir / tbl_id.ToString());
+    fs::create_directories(local_dir);
+
+    eloqstore::KvOptions opts;
+    opts.store_path = {local_dir.string()};
+    opts.enable_local_standby = true;
+    opts.standby_master_store_paths = {};
+    opts.pages_per_file_shift = 0;
+
+    eloqstore::EloqStore store(opts);
+    REQUIRE(store.Start("main", 1) == eloqstore::KvError::NoError);
+    UpsertRange(store, tbl_id, 0, 5000);
+    VerifyRange(store, tbl_id, 0, 5000, true);
+    store.Stop();
+
+    opts.standby_master_addr = "local";
+    opts.standby_master_store_paths = {remote_master_dir.string()};
+    eloqstore::EloqStore standby(opts);
+    REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+    eloqstore::GlobalReopenRequest reopen_req;
+    reopen_req.SetTag(std::to_string(1001));
+    standby.ExecSync(&reopen_req);
+    REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
+
+    VerifyRange(standby, tbl_id, 0, 5000, false);
+
+    standby.Stop();
+
+    fs::remove_all(dir);
+}
+
+TEST_CASE("standby reopen loads archived master data into empty standby",
+          "[standby]")
+{
+    fs::path dir = fs::temp_directory_path() / fs::path("standby-test");
+    fs::path master_dir = dir / "master";
+    fs::path standby_dir = dir / "standby";
+    fs::remove_all(dir);
+    fs::create_directories(master_dir);
+    fs::create_directories(standby_dir);
+
+    eloqstore::KvOptions master_opts;
+    master_opts.store_path = {master_dir.string()};
+    master_opts.enable_local_standby = true;
+    master_opts.standby_master_store_paths = {};
+    master_opts.pages_per_file_shift = 0;
+
+    eloqstore::KvOptions standby_opts = master_opts;
+    standby_opts.store_path = {standby_dir.string()};
+    standby_opts.standby_master_addr = "local";
+    standby_opts.standby_master_store_paths = {master_dir.string()};
+
+    eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+
+    {
+        eloqstore::EloqStore master(master_opts);
+        REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
+        UpsertRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, true);
+
+        eloqstore::GlobalArchiveRequest archive_req;
+        archive_req.SetTag(std::to_string(1001));
+        master.ExecSync(&archive_req);
+        REQUIRE(archive_req.Error() == eloqstore::KvError::NoError);
+
+        master.Stop();
+    }
+
+    {
+        eloqstore::EloqStore standby(standby_opts);
+        REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+
+        eloqstore::GlobalReopenRequest reopen_req;
+        reopen_req.SetTag(std::to_string(1001));
+        standby.ExecSync(&reopen_req);
+        REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
+
+        VerifyRange(standby, tbl_id, 0, 5000, true);
+
+        standby.Stop();
+    }
+
+    fs::remove_all(dir);
+}
+
+TEST_CASE("cloud reopen clears local-only partition when remote is empty",
+          "[standby][cloud]")
+{
+    fs::path temp_root =
+        fs::temp_directory_path() / fs::path("standby-cloud-clean-test");
+    fs::path local_dir = temp_root / "local";
+    fs::remove_all(temp_root);
+    fs::create_directories(local_dir);
+
+    std::string cloud_storage_path = cloud_archive_opts.cloud_store_path + "/" +
+                                     temp_root.filename().string();
+
+    eloqstore::KvOptions local_opts = cloud_archive_opts;
+    local_opts.store_path = {local_dir.string()};
+    local_opts.cloud_store_path.clear();
+    local_opts.pages_per_file_shift = 0;
+    local_opts.allow_reuse_local_caches = true;
+
+    eloqstore::KvOptions cloud_opts = cloud_archive_opts;
+    cloud_opts.store_path = {local_dir.string()};
+    cloud_opts.cloud_store_path = cloud_storage_path;
+    cloud_opts.pages_per_file_shift = 0;
+    cloud_opts.allow_reuse_local_caches = true;
+
+    CleanupStore(cloud_opts);
+
+    eloqstore::TableIdent tbl_id{"standby_cloud_tbl", 0};
+    const fs::path partition_path = local_dir / tbl_id.ToString();
+
+    {
+        eloqstore::EloqStore store(local_opts);
+        REQUIRE(store.Start("main", 1) == eloqstore::KvError::NoError);
+        UpsertRange(store, tbl_id, 0, 5000);
+        VerifyRange(store, tbl_id, 0, 5000, true);
+        store.Stop();
+    }
+
+    {
+        eloqstore::EloqStore store(cloud_opts);
+        REQUIRE(store.Start("main", 1) == eloqstore::KvError::NoError);
+
+        eloqstore::GlobalReopenRequest reopen_req;
+        store.ExecSync(&reopen_req);
+        REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
+
+        VerifyRange(store, tbl_id, 0, 5000, false);
+        REQUIRE(WaitForCondition(
+            5s, 100ms, [&]() { return !fs::exists(partition_path); }));
+
+        store.Stop();
+    }
+
+    CleanupStore(cloud_opts);
+    fs::remove_all(temp_root);
+}
 
 TEST_CASE("standby rsync replica follows master changes", "[standby]")
 {
@@ -68,61 +312,11 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
     eloqstore::TableIdent tbl_id{"standby_tbl", 0};
     const fs::path partition_path = standby_dir / tbl_id.ToString();
 
-    auto upsert_range =
-        [&](eloqstore::EloqStore &store, uint64_t begin, uint64_t end)
-    {
-        std::vector<eloqstore::WriteDataEntry> entries;
-        for (uint64_t i = begin; i < end; ++i)
-        {
-            entries.emplace_back(
-                Key(i), Value(i), 0, eloqstore::WriteOp::Upsert);
-        }
-        eloqstore::BatchWriteRequest req;
-        req.SetArgs(tbl_id, std::move(entries));
-        store.ExecSync(&req);
-        REQUIRE(req.Error() == eloqstore::KvError::NoError);
-    };
-    auto delete_range =
-        [&](eloqstore::EloqStore &store, uint64_t begin, uint64_t end)
-    {
-        std::vector<eloqstore::WriteDataEntry> entries;
-        for (uint64_t i = begin; i < end; ++i)
-        {
-            entries.emplace_back(Key(i), "", 0, eloqstore::WriteOp::Delete);
-        }
-        eloqstore::BatchWriteRequest req;
-        req.SetArgs(tbl_id, std::move(entries));
-        store.ExecSync(&req);
-        REQUIRE(req.Error() == eloqstore::KvError::NoError);
-    };
-
-    auto verify_range = [&](eloqstore::EloqStore &store,
-                            uint64_t begin,
-                            uint64_t end,
-                            bool expect_exists)
-    {
-        for (uint64_t i = begin; i < end; ++i)
-        {
-            eloqstore::ReadRequest req;
-            req.SetArgs(tbl_id, Key(i));
-            store.ExecSync(&req);
-            if (expect_exists)
-            {
-                REQUIRE(req.Error() == eloqstore::KvError::NoError);
-                REQUIRE(req.value_ == Value(i));
-            }
-            else
-            {
-                REQUIRE(req.Error() == eloqstore::KvError::NotFound);
-            }
-        }
-    };
-
     {
         eloqstore::EloqStore master(master_opts);
         REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
-        upsert_range(master, 0, 5000);
-        verify_range(master, 0, 5000, true);
+        UpsertRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, true);
 
         eloqstore::GlobalArchiveRequest archive_req;
         archive_req.SetTag(std::to_string(1001));
@@ -144,7 +338,7 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
         standby.ExecSync(&reopen_req);
         REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
 
-        verify_range(standby, 0, 5000, true);
+        VerifyRange(standby, tbl_id, 0, 5000, true);
 
         standby.Stop();
     }
@@ -153,8 +347,8 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
         eloqstore::EloqStore master(master_opts);
         REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
 
-        delete_range(master, 0, 5000);
-        verify_range(master, 0, 5000, false);
+        DeleteRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, false);
 
         eloqstore::GlobalArchiveRequest archive_req;
         archive_req.SetTag(std::to_string(2002));
@@ -177,48 +371,14 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
         REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
 
         REQUIRE(WaitForCondition(
-            10s,
-            100ms,
-            [&]()
-            {
-                if (!fs::exists(partition_path))
-                {
-                    return false;
-                }
-
-                bool has_manifest = false;
-                for (const auto &entry : fs::directory_iterator(partition_path))
-                {
-                    if (!entry.is_regular_file())
-                    {
-                        continue;
-                    }
-
-                    const std::string filename =
-                        entry.path().filename().string();
-                    const auto parsed = eloqstore::ParseFileName(filename);
-                    const auto &type = parsed.first;
-                    if (type == eloqstore::FileNameManifest)
-                    {
-                        has_manifest = true;
-                        continue;
-                    }
-
-                    if (type == eloqstore::FileNameData)
-                    {
-                        return false;
-                    }
-                }
-
-                return has_manifest;
-            }));
+            10s, 100ms, [&]() { return !fs::exists(partition_path); }));
 
         eloqstore::ReadRequest read_req;
         read_req.SetArgs(tbl_id, Key(0));
         standby.ExecSync(&read_req);
         REQUIRE(read_req.Error() == eloqstore::KvError::NotFound);
 
-        verify_range(standby, 0, 5000, false);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
 
         standby.Stop();
     }
@@ -226,8 +386,8 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
     {
         eloqstore::EloqStore master(master_opts);
         REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
-        upsert_range(master, 0, 5000);
-        verify_range(master, 0, 5000, true);
+        UpsertRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, true);
 
         eloqstore::GlobalArchiveRequest archive_req;
         archive_req.SetTag(std::to_string(3003));
@@ -249,7 +409,7 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
         standby.ExecSync(&reopen_req);
         REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
 
-        verify_range(standby, 0, 5000, true);
+        VerifyRange(standby, tbl_id, 0, 5000, true);
 
         standby.Stop();
     }
@@ -257,7 +417,7 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
     {
         eloqstore::EloqStore new_master(new_master_opts);
         REQUIRE(new_master.Start("main", 2) == eloqstore::KvError::NoError);
-        upsert_range(new_master, 5001, 10000);
+        UpsertRange(new_master, tbl_id, 5001, 10000);
         eloqstore::GlobalArchiveRequest archive_req;
         archive_req.SetTag(std::to_string(2002));
         new_master.ExecSync(&archive_req);
@@ -323,8 +483,8 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
                 return has_manifest;
             }));
 
-        verify_range(standby, 0, 5000, false);
-        verify_range(standby, 5001, 10000, true);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
+        VerifyRange(standby, tbl_id, 5001, 10000, true);
 
         standby.Stop();
     }
@@ -365,68 +525,19 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
     eloqstore::TableIdent tbl_id{"standby_cloud_tbl", 0};
     const fs::path partition_path = standby_dir / tbl_id.ToString();
 
-    auto upsert_range =
-        [&](eloqstore::EloqStore &store, uint64_t begin, uint64_t end)
-    {
-        std::vector<eloqstore::WriteDataEntry> entries;
-        for (uint64_t i = begin; i < end; ++i)
-        {
-            entries.emplace_back(
-                Key(i), Value(i), 0, eloqstore::WriteOp::Upsert);
-        }
-        eloqstore::BatchWriteRequest req;
-        req.SetArgs(tbl_id, std::move(entries));
-        store.ExecSync(&req);
-        REQUIRE(req.Error() == eloqstore::KvError::NoError);
-    };
-    auto delete_range =
-        [&](eloqstore::EloqStore &store, uint64_t begin, uint64_t end)
-    {
-        std::vector<eloqstore::WriteDataEntry> entries;
-        for (uint64_t i = begin; i < end; ++i)
-        {
-            entries.emplace_back(Key(i), "", 0, eloqstore::WriteOp::Delete);
-        }
-        eloqstore::BatchWriteRequest req;
-        req.SetArgs(tbl_id, std::move(entries));
-        store.ExecSync(&req);
-        REQUIRE(req.Error() == eloqstore::KvError::NoError);
-    };
-    auto verify_range = [&](eloqstore::EloqStore &store,
-                            uint64_t begin,
-                            uint64_t end,
-                            bool expect_exists)
-    {
-        for (uint64_t i = begin; i < end; ++i)
-        {
-            eloqstore::ReadRequest req;
-            req.SetArgs(tbl_id, Key(i));
-            store.ExecSync(&req);
-            if (expect_exists)
-            {
-                REQUIRE(req.Error() == eloqstore::KvError::NoError);
-                REQUIRE(req.value_ == Value(i));
-            }
-            else
-            {
-                REQUIRE(req.Error() == eloqstore::KvError::NotFound);
-            }
-        }
-    };
-
     {
         eloqstore::EloqStore master(master_opts);
         REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
-        upsert_range(master, 0, 5000);
-        verify_range(master, 0, 5000, true);
+        UpsertRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, true);
 
         eloqstore::GlobalArchiveRequest archive_req;
         archive_req.SetTag(std::to_string(1001));
         master.ExecSync(&archive_req);
         REQUIRE(archive_req.Error() == eloqstore::KvError::NoError);
 
-        delete_range(master, 0, 5000);
-        verify_range(master, 0, 5000, false);
+        DeleteRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, false);
 
         master.Stop();
     }
@@ -438,14 +549,14 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
 
         // Load the latest cloud state into memory before reopening to the
         // archived snapshot.
-        verify_range(standby, 0, 5000, false);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
 
         eloqstore::GlobalReopenRequest reopen_req;
         reopen_req.SetTag(std::to_string(1001));
         standby.ExecSync(&reopen_req);
         REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
 
-        verify_range(standby, 0, 5000, true);
+        VerifyRange(standby, tbl_id, 0, 5000, true);
 
         standby.Stop();
     }
@@ -454,8 +565,8 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
         eloqstore::EloqStore master(master_opts);
         REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
 
-        delete_range(master, 0, 5000);
-        verify_range(master, 0, 5000, false);
+        DeleteRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, false);
 
         eloqstore::GlobalArchiveRequest archive_req;
         archive_req.SetTag(std::to_string(2002));
@@ -470,7 +581,7 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
         eloqstore::EloqStore standby(standby_opts);
         REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
 
-        verify_range(standby, 0, 5000, false);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
 
         eloqstore::GlobalReopenRequest reopen_req;
         reopen_req.SetTag(std::to_string(2002));
@@ -518,7 +629,7 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
         standby.ExecSync(&read_req);
         REQUIRE(read_req.Error() == eloqstore::KvError::NotFound);
 
-        verify_range(standby, 0, 5000, false);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
 
         standby.Stop();
     }
@@ -526,14 +637,14 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
     {
         eloqstore::EloqStore new_master(new_master_opts);
         REQUIRE(new_master.Start("main", 2) == eloqstore::KvError::NoError);
-        upsert_range(new_master, 5001, 10000);
+        UpsertRange(new_master, tbl_id, 5001, 10000);
         eloqstore::GlobalArchiveRequest archive_req;
         archive_req.SetTag(std::to_string(2002));
         new_master.ExecSync(&archive_req);
         REQUIRE(archive_req.Error() == eloqstore::KvError::NoError);
 
-        delete_range(new_master, 5001, 10000);
-        verify_range(new_master, 5001, 10000, false);
+        DeleteRange(new_master, tbl_id, 5001, 10000);
+        VerifyRange(new_master, tbl_id, 5001, 10000, false);
 
         new_master.Stop();
     }
@@ -544,8 +655,8 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
         eloqstore::EloqStore standby(standby_opts);
         REQUIRE(standby.Start("main", 2) == eloqstore::KvError::NoError);
 
-        verify_range(standby, 0, 5000, false);
-        verify_range(standby, 5001, 10000, false);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
+        VerifyRange(standby, tbl_id, 5001, 10000, false);
 
         eloqstore::GlobalReopenRequest reopen_req;
         reopen_req.SetTag(std::to_string(2002));
@@ -597,8 +708,8 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
                 return has_manifest;
             }));
 
-        verify_range(standby, 0, 5000, false);
-        verify_range(standby, 5001, 10000, true);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
+        VerifyRange(standby, tbl_id, 5001, 10000, true);
 
         standby.Stop();
     }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "clean" reopen option to mark reopens that install an empty snapshot.

* **Refactor**
  * Reduced verbose debug logging and streamlined local partition discovery and cleanup scheduling.

* **Behavior**
  * Missing external snapshots now fall back to an empty snapshot; local manifest/partition cleanup can be triggered immediately during GC and surface errors.

* **Tests**
  * Expanded standby/cloud tests covering empty/missing snapshots, archival restores, and local-cleanup scenarios.

* **Chores**
  * .gitignore updated to ignore .codex files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->