### PR TITLE
fix: retry ResourceMissing requests via auto reopen

### DIFF
--- a/include/eloq_store.h
+++ b/include/eloq_store.h
@@ -33,6 +33,7 @@ struct CloudObjectInfo;
 namespace eloqstore
 {
 class Shard;
+class EloqStore;
 
 enum class RequestType : uint8_t
 {
@@ -123,6 +124,10 @@ class KvRequest
 public:
     virtual ~KvRequest() = default;
     virtual RequestType Type() const = 0;
+    virtual bool AutoReopenRetry() const
+    {
+        return false;
+    }
     bool ReadOnly() const;
     KvError Error() const;
     bool RetryableErr() const;
@@ -143,6 +148,7 @@ protected:
     TableIdent tbl_id_;
     uint64_t user_data_{0};
     std::function<void(KvRequest *)> callback_{nullptr};
+    uint8_t reopen_retry_remaining_{0};
 #ifdef ELOQ_MODULE_ENABLED
     mutable bthread::ConditionVariable cv_;
     mutable bthread::Mutex mutex_;
@@ -164,6 +170,10 @@ public:
     RequestType Type() const override
     {
         return RequestType::Read;
+    }
+    bool AutoReopenRetry() const override
+    {
+        return true;
     }
     void SetArgs(TableIdent tbl_id, const char *key);
     void SetArgs(TableIdent tbl_id, std::string_view key);
@@ -191,6 +201,10 @@ public:
     {
         return RequestType::Floor;
     }
+    bool AutoReopenRetry() const override
+    {
+        return true;
+    }
     void SetArgs(TableIdent tbl_id, const char *key);
     void SetArgs(TableIdent tid, std::string_view key);
     void SetArgs(TableIdent tid, std::string key);
@@ -213,6 +227,10 @@ public:
     RequestType Type() const override
     {
         return RequestType::Scan;
+    }
+    bool AutoReopenRetry() const override
+    {
+        return true;
     }
     /**
      * @brief Set the scan range.
@@ -857,6 +875,7 @@ public:
     {
         req->user_data_ = data;
         req->callback_ = std::move(callback);
+        req->reopen_retry_remaining_ = options_.auto_reopen_retry_times;
         return SendRequest(req);
     }
 
@@ -919,6 +938,7 @@ private:
     std::atomic<StoreMode> store_mode_{StoreMode::Local};
 
     friend class Shard;
+    friend class KvRequest;
     friend class AsyncIoManager;
     friend class IouringMgr;
     friend class WriteTask;

--- a/include/error.h
+++ b/include/error.h
@@ -12,22 +12,24 @@ namespace eloqstore
 {
 enum struct KvError : uint8_t
 {
-    NoError = 0,    // Success.
-    InvalidArgs,    // Invalid inputs/options (e.g., bad path/key).
-    NotFound,       // Missing key/file/manifest/term file.
-    NotRunning,     // Store not started or already stopping.
-    Corrupted,      // Corrupted manifest/term data or checksum mismatch.
-    EndOfFile,      // Manifest read hit EOF or truncated padding.
-    OutOfSpace,     // Disk/cache space exhausted (ENOSPC or cache limit).
-    OutOfMem,       // Memory allocation failure or cache eviction failed.
-    OpenFileLimit,  // Too many open files or io_uring fd slots.
-    TryAgain,       // Retryable condition (EAGAIN/EINTR/ENOBUFS).
-    Busy,           // Resource/device busy (EBUSY).
-    Timeout,        // Cloud HTTP/CURL timeout or retryable status.
-    NoPermission,   // Permission denied (EPERM).
-    CloudErr,       // Cloud service error (non-timeout HTTP/CURL).
-    IoFail,         // Unclassified local I/O error.
-    ExpiredTerm,    // Cloud term file indicates stale process term.
+    NoError = 0,      // Success.
+    InvalidArgs,      // Invalid inputs/options (e.g., bad path/key).
+    NotFound,         // Resource not found.
+    ResourceMissing,  // Expected data file/manifest/term file/cloud object is
+                      // missing unexpectedly.
+    NotRunning,       // Store not started or already stopping.
+    Corrupted,        // Corrupted manifest/term data or checksum mismatch.
+    EndOfFile,        // Manifest read hit EOF or truncated padding.
+    OutOfSpace,       // Disk/cache space exhausted (ENOSPC or cache limit).
+    OutOfMem,         // Memory allocation failure or cache eviction failed.
+    OpenFileLimit,    // Too many open files or io_uring fd slots.
+    TryAgain,         // Retryable condition (EAGAIN/EINTR/ENOBUFS).
+    Busy,             // Resource/device busy (EBUSY).
+    Timeout,          // Cloud HTTP/CURL timeout or retryable status.
+    NoPermission,     // Permission denied (EPERM).
+    CloudErr,         // Cloud service error (non-timeout HTTP/CURL).
+    IoFail,           // Unclassified local I/O error.
+    ExpiredTerm,      // Cloud term file indicates stale process term.
     OssInsufficientStorage,  // Object storage out of capacity (HTTP 507).
     AlreadyExists,  // Branch or table already exists (e.g., HTTP 409 or
                     // EEXIST).
@@ -43,6 +45,8 @@ constexpr const char *ErrorString(KvError err)
         return "Invalid arguments";
     case KvError::NotFound:
         return "Resource not found";
+    case KvError::ResourceMissing:
+        return "Expected resource missing";
     case KvError::NotRunning:
         return "EloqStore is not running";
     case KvError::EndOfFile:

--- a/include/kv_options.h
+++ b/include/kv_options.h
@@ -307,6 +307,11 @@ struct KvOptions
      * enabled.
      */
     uint16_t prewarm_task_count = 3;
+    /**
+     * @brief Maximum automatic reopen-retry attempts when a request fails with
+     * missing underlying resources in cloud/standby mode.
+     */
+    uint8_t auto_reopen_retry_times = 10;
 
     /**
      * @brief Filter function to determine which partitions belong to this

--- a/include/standby_service.h
+++ b/include/standby_service.h
@@ -147,8 +147,8 @@ private:
 
     fs::path TablePath(const TableIdent &tbl_id) const;
     std::string RemotePartitionPath(const TableIdent &tbl_id) const;
-    std::string RemoteArchiveManifestPath(const TableIdent &tbl_id,
-                                          std::string_view archive_tag) const;
+    std::string RemoteManifestPath(const TableIdent &tbl_id,
+                                   std::string_view archive_tag) const;
     std::string RemoteSpec(const std::string &path, bool directory) const;
 
     EloqStore *store_{nullptr};

--- a/include/storage/shard.h
+++ b/include/storage/shard.h
@@ -5,7 +5,9 @@
 #include <cstdio>
 #include <ctime>
 #include <memory>
+#include <unordered_map>
 #include <utility>  // NOLINT(build/include_order)
+#include <vector>
 
 #include "circular_queue.h"
 #include "eloq_store.h"
@@ -32,7 +34,7 @@ class CloudStoreMgr;
 class Shard
 {
 public:
-    Shard(const EloqStore *store, size_t shard_id, uint32_t fd_limit);
+    Shard(EloqStore *store, size_t shard_id, uint32_t fd_limit);
     KvError Init();
     void Start();
     void Stop();
@@ -67,14 +69,13 @@ public:
 #ifdef ELOQ_MODULE_ENABLED
     std::atomic<ShardStatus> running_status_{ShardStatus::Running};
 #endif
-    const EloqStore *store_;
+    EloqStore *store_;
     const size_t shard_id_{0};
     boost::context::continuation main_;
     uint64_t ts_{};
     KvTask *running_{};
     CircularQueue<KvTask *> ready_tasks_;
     CircularQueue<KvTask *> low_priority_ready_tasks_;
-    size_t running_writing_tasks_{};
 
 private:
     void WorkLoop();
@@ -83,6 +84,7 @@ private:
     void OnTaskFinished(KvTask *task);
     void OnReceivedReq(KvRequest *req);
     bool ProcessReq(KvRequest *req);
+    void EnqueueForAutoReopen(KvRequest *req);
     void TryStartPendingWrite(const TableIdent &tbl_id);
     void TryDispatchPendingWrites();
 
@@ -113,8 +115,8 @@ private:
     {
         task->req_ = req;
         task->status_ = TaskStatus::Ongoing;
+        task->needs_auto_reopen_ = false;
         running_ = task;
-
         task->coro_ = boost::context::callcc(
             std::allocator_arg,
             stack_allocator_,
@@ -147,13 +149,35 @@ private:
                 // Save request type before SetDone
                 RequestType request_type = task->req_->Type();
 #endif
-                task->req_->SetDone(err);
-                task->req_ = nullptr;
+                KvRequest *req = task->req_;
+                bool request_completed = true;
+                if (__builtin_expect(err != KvError::ResourceMissing, 1))
+                {
+                    req->SetDone(err);
+                }
+                else
+                {
+                    const StoreMode mode = shard->store_->Mode();
+                    if (req->AutoReopenRetry() &&
+                        req->reopen_retry_remaining_ > 0 &&
+                        (mode == StoreMode::Cloud ||
+                         mode == StoreMode::StandbyReplica))
+                    {
+                        CHECK(req->TableId().IsValid());
+                        --req->reopen_retry_remaining_;
+                        task->needs_auto_reopen_ = true;
+                    }
+                    request_completed = !task->needs_auto_reopen_;
+                    if (request_completed)
+                    {
+                        req->SetDone(err);
+                    }
+                }
                 task->status_ = TaskStatus::Finished;
 
 #ifdef ELOQSTORE_WITH_TXSERVICE
                 // Collect latency metric when request completes
-                if (this->store_->EnableMetrics())
+                if (request_completed && this->store_->EnableMetrics())
                 {
                     const char *request_type_str =
                         RequestTypeToString(request_type);
@@ -246,6 +270,14 @@ private:
     };
     std::unordered_map<TableIdent, PendingWriteQueue> pending_queues_;
 
+    struct PendingReopenState
+    {
+        bool inflight{false};
+        std::vector<KvRequest *> waiters;
+        std::unique_ptr<ReopenRequest> request;
+    };
+    std::unordered_map<TableIdent, PendingReopenState> pending_reopens_;
+
 #ifdef ELOQ_MODULE_ENABLED
     std::atomic<size_t> req_queue_size_{0};
 #endif
@@ -262,5 +294,6 @@ private:
 
     friend class EloqStoreModule;
     friend class EloqStore;
+    friend class KvRequest;
 };
 }  // namespace eloqstore

--- a/include/tasks/reopen_task.h
+++ b/include/tasks/reopen_task.h
@@ -13,12 +13,5 @@ public:
         return TaskType::Reopen;
     }
     KvError Reopen(const TableIdent &tbl_id);
-    void SetRequest(ReopenRequest *req)
-    {
-        request_ = req;
-    }
-
-private:
-    ReopenRequest *request_{nullptr};
 };
 }  // namespace eloqstore

--- a/include/tasks/task.h
+++ b/include/tasks/task.h
@@ -119,6 +119,7 @@ public:
     uint32_t inflight_io_{0};
     int io_res_{0};
     uint32_t io_flags_{0};
+    bool needs_auto_reopen_{false};
 
     TaskStatus status_{TaskStatus::Idle};
     KvRequest *req_{nullptr};

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -488,10 +488,19 @@ std::pair<Page, KvError> IouringMgr::ReadPage(const TableIdent &tbl_id,
     auto [file_id, offset] = ConvFilePageId(fp_id);
     std::string branch_name;
     uint64_t term;
-    CHECK(GetBranchNameAndTerm(tbl_id, file_id, branch_name, term))
-        << "ReadPage, not found branch/term for file id " << file_id
-        << " in table " << tbl_id;
+    if (!GetBranchNameAndTerm(tbl_id, file_id, branch_name, term))
+    {
+        LOG(WARNING) << "ReadPage missing branch/term for fp_id=" << fp_id
+                     << ", file_id=" << file_id << ", shift="
+                     << static_cast<uint32_t>(options_->pages_per_file_shift)
+                     << " in table " << tbl_id;
+        return {std::move(page), KvError::ResourceMissing};
+    }
     auto [fd_ref, err] = OpenFD(tbl_id, file_id, true, branch_name, term);
+    if (err == KvError::NotFound)
+    {
+        err = KvError::ResourceMissing;
+    }
     if (err != KvError::NoError)
     {
         return {std::move(page), err};
@@ -584,14 +593,16 @@ KvError IouringMgr::ReadPages(const TableIdent &tbl_id,
         auto [file_id, offset] = ConvFilePageId(fp_id);
         std::string branch_name;
         uint64_t term;
-        CHECK(GetBranchNameAndTerm(tbl_id, file_id, branch_name, term))
-            << "ReadPages, not found branch/term for file id " << file_id
-            << " in table " << tbl_id;
-        auto [fd_ref, err] = OpenFD(tbl_id, file_id, true, branch_name, term);
-        if (err != KvError::NoError)
+        if (!GetBranchNameAndTerm(tbl_id, file_id, branch_name, term))
         {
-            return err;
+            LOG(WARNING) << "ReadPages missing branch/term for file id "
+                         << file_id << " in table " << tbl_id;
+            return KvError::ResourceMissing;
         }
+        auto [fd_ref, err] = OpenFD(tbl_id, file_id, true, branch_name, term);
+        if (err == KvError::NotFound)
+            err = KvError::ResourceMissing;
+        CHECK_KV_ERR(err);
         reqs[i] = ReadReq(ThdTask(), std::move(fd_ref), offset);
         i++;
     }
@@ -1294,7 +1305,8 @@ std::pair<IouringMgr::LruFD::Ref, KvError> IouringMgr::OpenOrCreateFD(
         {
             error = ToKvError(fd);
         }
-        if (file_id == LruFD::kManifest && error == KvError::NotFound)
+        if (file_id == LruFD::kManifest &&
+            (error == KvError::NotFound || error == KvError::ResourceMissing))
         {
             // Manifest not found, this is normal so don't log it.
         }
@@ -1339,9 +1351,8 @@ bool IouringMgr::GetBranchNameAndTerm(const TableIdent &tbl_id,
         return false;
     }
     const auto &mapping = it_term_tbl->second;
-    bool res =
-        ::eloqstore::GetBranchNameAndTerm(mapping, file_id, branch_name, term);
-    return res;
+    return ::eloqstore::GetBranchNameAndTerm(
+        mapping, file_id, branch_name, term);
 }
 
 void IouringMgr::SetBranchFileIdTerm(const TableIdent &tbl_id,

--- a/src/eloq_store.cpp
+++ b/src/eloq_store.cpp
@@ -988,6 +988,7 @@ bool EloqStore::ExecAsyn(KvRequest *req)
 {
     req->user_data_ = 0;
     req->callback_ = nullptr;
+    req->reopen_retry_remaining_ = options_.auto_reopen_retry_times;
     return SendRequest(req);
 }
 
@@ -995,6 +996,7 @@ void EloqStore::ExecSync(KvRequest *req)
 {
     req->user_data_ = 0;
     req->callback_ = nullptr;
+    req->reopen_retry_remaining_ = options_.auto_reopen_retry_times;
     if (SendRequest(req))
     {
         req->Wait();
@@ -2535,13 +2537,15 @@ void KvRequest::SetDone(KvError err)
     }
     if (has_async_cb)
     {
-        callback_(this);
+        auto callback = std::move(callback_);
+        callback(this);
     }
 #else
     done_.store(true, std::memory_order_release);
     if (callback_)
     {
-        callback_(this);
+        auto callback = std::move(callback_);
+        callback(this);
     }
     else
     {

--- a/src/kv_options.cpp
+++ b/src/kv_options.cpp
@@ -412,6 +412,7 @@ bool KvOptions::operator==(const KvOptions &other) const
            allow_reuse_local_caches == other.allow_reuse_local_caches &&
            prewarm_cloud_cache == other.prewarm_cloud_cache &&
            prewarm_task_count == other.prewarm_task_count &&
+           auto_reopen_retry_times == other.auto_reopen_retry_times &&
            store_path == other.store_path &&
            store_path_weights == other.store_path_weights &&
            cloud_store_path == other.cloud_store_path &&

--- a/src/standby_service.cpp
+++ b/src/standby_service.cpp
@@ -613,7 +613,7 @@ std::string StandbyService::RemotePartitionPath(const TableIdent &tbl_id) const
     return remote_path;
 }
 
-std::string StandbyService::RemoteArchiveManifestPath(
+std::string StandbyService::RemoteManifestPath(
     const TableIdent &tbl_id, std::string_view archive_tag) const
 {
     std::string remote_path = RemotePartitionPath(tbl_id);
@@ -622,8 +622,16 @@ std::string StandbyService::RemoteArchiveManifestPath(
         return {};
     }
     remote_path.push_back('/');
-    remote_path.append(
-        BranchArchiveName(MainBranchName, store_->Term(), archive_tag));
+    if (archive_tag.empty())
+    {
+        remote_path.append(
+            BranchManifestFileName(MainBranchName, store_->Term()));
+    }
+    else
+    {
+        remote_path.append(
+            BranchArchiveName(MainBranchName, store_->Term(), archive_tag));
+    }
     return remote_path;
 }
 
@@ -667,16 +675,9 @@ KvError StandbyService::StartRsyncJob(std::list<InflightJob>::iterator it)
     {
         return KvError::InvalidArgs;
     }
-    if (job->archive_tag.empty())
-    {
-        LOG(ERROR) << "StandbyService::StartRsyncJob empty archive tag for "
-                   << job->tbl_id;
-        return KvError::InvalidArgs;
-    }
-
     std::string remote_partition_path = RemotePartitionPath(job->tbl_id);
     std::string remote_manifest_path =
-        RemoteArchiveManifestPath(job->tbl_id, job->archive_tag);
+        RemoteManifestPath(job->tbl_id, job->archive_tag);
     if (remote_partition_path.empty() || remote_manifest_path.empty())
     {
         LOG(ERROR) << "StandbyService: remote partition path missing for "
@@ -1019,8 +1020,7 @@ void StandbyService::HandleExitedChild(std::list<InflightJob>::iterator it,
         fs::path manifest_tmp = table_dir / kManifestTmp;
         std::string manifest_tmp_path = manifest_tmp.string();
         std::string remote_manifest_spec = RemoteSpec(
-            RemoteArchiveManifestPath(rsync->tbl_id, rsync->archive_tag),
-            false);
+            RemoteManifestPath(rsync->tbl_id, rsync->archive_tag), false);
         std::vector<const char *> argv = {"rsync",
                                           "-a",
                                           "--inplace",

--- a/src/storage/index_page_manager.cpp
+++ b/src/storage/index_page_manager.cpp
@@ -488,7 +488,8 @@ KvError IndexPageManager::InstallExternalSnapshot(const TableIdent &tbl_ident,
                 KvError sync_err = cloud_mgr->DownloadFile(
                     tbl_ident, max_file_id, branch_name, term, true, offset);
                 if (sync_err != KvError::NoError &&
-                    sync_err != KvError::NotFound)
+                    sync_err != KvError::NotFound &&
+                    sync_err != KvError::ResourceMissing)
                 {
                     return sync_err;
                 }
@@ -514,7 +515,7 @@ KvError IndexPageManager::InstallExternalSnapshot(const TableIdent &tbl_ident,
     }
     if (err != KvError::NoError)
     {
-        if (err == KvError::NotFound)
+        if (err == KvError::NotFound || err == KvError::ResourceMissing)
         {
             LOG(INFO) << "InstallExternalSnapshot missing remote state for "
                       << "table " << tbl_ident << ", tag " << reopen_tag;

--- a/src/storage/shard.cpp
+++ b/src/storage/shard.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -44,7 +45,7 @@ DEFINE_uint64(max_processing_time_microseconds,
               "Max processing time in microseconds for low priority tasks.");
 #endif
 
-Shard::Shard(const EloqStore *store, size_t shard_id, uint32_t fd_limit)
+Shard::Shard(EloqStore *store, size_t shard_id, uint32_t fd_limit)
     : store_(store),
       shard_id_(shard_id),
       page_pool_(&store->options_),
@@ -245,6 +246,56 @@ bool Shard::AddKvRequest(KvRequest *req)
     return ret;
 }
 
+void Shard::EnqueueForAutoReopen(KvRequest *req)
+{
+    const TableIdent tbl_id = req->TableId();
+    auto &state = pending_reopens_[tbl_id];
+    state.waiters.push_back(req);
+    if (state.inflight)
+    {
+        return;
+    }
+    state.inflight = true;
+
+    auto [it_q, inserted] = pending_queues_.try_emplace(tbl_id);
+    PendingWriteQueue &pending_q = it_q->second;
+    if (state.request == nullptr)
+    {
+        state.request = std::make_unique<ReopenRequest>();
+    }
+    ReopenRequest *reopen_req = state.request.get();
+    reopen_req->SetArgs(tbl_id);
+    reopen_req->SetTag("");
+    reopen_req->SetClean(false);
+    reopen_req->callback_ = [this, tbl_id](KvRequest *done_req)
+    {
+        KvError reopen_err = done_req->Error();
+        EloqStore *store = store_;
+        std::vector<KvRequest *> waiters;
+        std::unique_ptr<ReopenRequest> owned_req;
+        auto it = pending_reopens_.find(tbl_id);
+        if (it != pending_reopens_.end())
+        {
+            waiters = std::move(it->second.waiters);
+            owned_req = std::move(it->second.request);
+            pending_reopens_.erase(it);
+        }
+        for (KvRequest *pending_req : waiters)
+        {
+            if (reopen_err != KvError::NoError)
+            {
+                pending_req->SetDone(reopen_err);
+            }
+            else if (!store->SendRequest(pending_req))
+            {
+                pending_req->SetDone(KvError::NotRunning);
+            }
+        }
+    };
+    pending_q.PushFront(reopen_req);
+    TryStartPendingWrite(tbl_id);
+}
+
 void Shard::AddPendingCompact(const TableIdent &tbl_id)
 {
     // Send CompactRequest from internal.
@@ -377,10 +428,6 @@ void Shard::OnReceivedReq(KvRequest *req)
     {
         auto *wreq = reinterpret_cast<WriteRequest *>(req);
         auto [it, inserted] = pending_queues_.try_emplace(req->tbl_id_);
-        if (inserted)
-        {
-            ++running_writing_tasks_;
-        }
         it->second.PushBack(wreq);
         TryStartPendingWrite(req->tbl_id_);
         return;
@@ -546,7 +593,6 @@ bool Shard::ProcessReq(KvRequest *req)
     case RequestType::Reopen:
     {
         ReopenTask *task = task_mgr_.GetReopenTask(req->TableId());
-        task->SetRequest(static_cast<ReopenRequest *>(req));
         auto lbd = [task, req]() -> KvError
         { return task->Reopen(req->TableId()); };
         StartTask(task, req, lbd);
@@ -757,6 +803,11 @@ finish:
 
 void Shard::OnTaskFinished(KvTask *task)
 {
+    KvRequest *req = task->req_;
+    const bool auto_reopen = task->needs_auto_reopen_;
+    task->req_ = nullptr;
+    task->needs_auto_reopen_ = false;
+
     if (!task->ReadOnly())
     {
         auto wtask = reinterpret_cast<WriteTask *>(task);
@@ -769,7 +820,6 @@ void Shard::OnTaskFinished(KvTask *task)
         {
             // No more write requests, remove the pending queue.
             pending_queues_.erase(it);
-            --running_writing_tasks_;
         }
         TryDispatchPendingWrites();
     }
@@ -777,6 +827,13 @@ void Shard::OnTaskFinished(KvTask *task)
     {
         task_mgr_.FreeTask(task);
     }
+
+    if (__builtin_expect(!auto_reopen, 1))
+    {
+        return;
+    }
+
+    EnqueueForAutoReopen(req);
 }
 
 #ifdef ELOQ_MODULE_ENABLED
@@ -850,7 +907,6 @@ void Shard::WorkOneRound()
     {
         ExecuteReadyTasks();
     }
-
 #ifdef ELOQSTORE_WITH_TXSERVICE
     // Metrics collection: end of round
     if (store_->EnableMetrics() && !is_idle_round)

--- a/src/tasks/reopen_task.cpp
+++ b/src/tasks/reopen_task.cpp
@@ -13,11 +13,11 @@ namespace eloqstore
 
 KvError ReopenTask::Reopen(const TableIdent &tbl_id)
 {
-    CHECK(request_ != nullptr);
+    auto *request = static_cast<ReopenRequest *>(req_);
+    CHECK(request != nullptr);
     StoreMode mode = shard->store_->Mode();
     if (mode == StoreMode::Local)
     {
-        request_ = nullptr;
         return KvError::InvalidArgs;
     }
     StandbyService *standby_service = nullptr;
@@ -29,18 +29,11 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
         {
             LOG(ERROR) << "Reopen " << tbl_id
                        << " failed: standby_service is null, tag "
-                       << request_->Tag();
-            request_ = nullptr;
+                       << request->Tag();
             return KvError::InvalidArgs;
         }
-        tag = request_->Tag();
-        if (tag.empty())
-        {
-            LOG(ERROR) << "Reopen " << tbl_id << " failed: empty tag";
-            request_ = nullptr;
-            return KvError::InvalidArgs;
-        }
-        if (!request_->Clean())
+        tag = request->Tag();
+        if (!request->Clean())
         {
             KvTask *current_task = ThdTask();
             CHECK(current_task != nullptr);
@@ -50,39 +43,37 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
                 LOG(ERROR) << "Reopen " << tbl_id
                            << " rsync enqueue failed, tag " << tag << ", error "
                            << static_cast<uint32_t>(enqueue_err);
-                request_ = nullptr;
                 return enqueue_err;
             }
             current_task->WaitIo();
             KvError sync_err = static_cast<KvError>(current_task->io_res_);
-            if (sync_err != KvError::NoError && sync_err != KvError::NotFound)
+            if (sync_err != KvError::NoError && sync_err != KvError::NotFound &&
+                sync_err != KvError::ResourceMissing)
             {
                 LOG(ERROR) << "Reopen " << tbl_id << " rsync failed, tag "
                            << tag << ", error "
                            << static_cast<uint32_t>(sync_err);
-                request_ = nullptr;
                 return sync_err;
             }
         }
     }
 
     KvError err = KvError::NoError;
-    if (request_->Clean())
+    if (request->Clean())
     {
         err = shard->IndexManager()->InstallEmptySnapshot(tbl_id, cow_meta_);
     }
     else
     {
         err = shard->IndexManager()->InstallExternalSnapshot(
-            tbl_id, cow_meta_, request_->Tag());
+            tbl_id, cow_meta_, request->Tag());
     }
     if (err != KvError::NoError)
     {
         LOG(ERROR) << "Reopen " << tbl_id
-                   << " InstallExternalSnapshot failed, tag " << request_->Tag()
+                   << " InstallExternalSnapshot failed, tag " << request->Tag()
                    << ", mode " << static_cast<int>(mode) << ", error "
                    << static_cast<uint32_t>(err);
-        request_ = nullptr;
         return err;
     }
     if (mode == StoreMode::Cloud && Options()->prewarm_cloud_cache)
@@ -103,9 +94,8 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
         {
             LOG(ERROR) << "Reopen " << tbl_id
                        << " failed to cleanup local partition files, tag "
-                       << request_->Tag() << ", error "
+                       << request->Tag() << ", error "
                        << static_cast<uint32_t>(err);
-            request_ = nullptr;
             return err;
         }
     }
@@ -113,7 +103,6 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
     {
         shard->AddPendingLocalGc(tbl_id);
     }
-    request_ = nullptr;
     return err;
 }
 

--- a/tests/standby.cpp
+++ b/tests/standby.cpp
@@ -1,7 +1,11 @@
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>  // NOLINT(build/c++17)
 #include <functional>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -21,6 +25,13 @@ using test_util::Value;
 
 namespace
 {
+constexpr std::string_view kStaleManifestTableName =
+    "standby_cloud_stale_manifest";
+constexpr std::string_view kStaleManifestTempRootName =
+    "standby-cloud-stale-manifest-test";
+constexpr uint64_t kStaleManifestPhaseBegin = 0;
+constexpr uint64_t kStaleManifestPhaseEnd = 20000;
+
 template <typename Pred>
 bool WaitForCondition(std::chrono::milliseconds timeout,
                       std::chrono::milliseconds step,
@@ -92,7 +103,141 @@ void VerifyRange(eloqstore::EloqStore &store,
         }
     }
 }
+
+void ReopenStore(eloqstore::EloqStore &store,
+                 std::optional<std::string> tag = std::nullopt)
+{
+    eloqstore::GlobalReopenRequest reopen_req;
+    if (tag.has_value())
+    {
+        reopen_req.SetTag(std::move(*tag));
+    }
+    store.ExecSync(&reopen_req);
+    REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
+}
+
+std::vector<std::string> ListDataFiles(const std::vector<std::string> &files)
+{
+    std::vector<std::string> data_files;
+    for (const std::string &filename : files)
+    {
+        const auto [type, suffix] = eloqstore::ParseFileName(filename);
+        (void) suffix;
+        if (type == eloqstore::FileNameData)
+        {
+            data_files.push_back(filename);
+        }
+    }
+    return data_files;
+}
+
+void RemoveLocalNonManifestFiles(const fs::path &partition_path)
+{
+    for (const auto &entry : fs::directory_iterator(partition_path))
+    {
+        if (!entry.is_regular_file())
+        {
+            continue;
+        }
+
+        const std::string filename = entry.path().filename().string();
+        const auto [type, suffix] = eloqstore::ParseFileName(filename);
+        (void) suffix;
+        std::string_view branch_name;
+        const bool is_current_term =
+            eloqstore::ParseCurrentTermFilename(filename, branch_name);
+        if (type != eloqstore::FileNameManifest && !is_current_term)
+        {
+            fs::remove(entry.path());
+        }
+    }
+}
+
+eloqstore::KvError ScanRange(eloqstore::EloqStore &store,
+                             const eloqstore::TableIdent &tbl_id,
+                             uint64_t begin,
+                             uint64_t end)
+{
+    eloqstore::ScanRequest req;
+    req.SetArgs(tbl_id, Key(begin), Key(end));
+    store.ExecSync(&req);
+    return req.Error();
+}
+
+std::vector<std::string> ListLocalDataFiles(const fs::path &partition_path)
+{
+    std::vector<std::string> files;
+    if (!fs::exists(partition_path))
+    {
+        return files;
+    }
+
+    for (const auto &entry : fs::directory_iterator(partition_path))
+    {
+        if (!entry.is_regular_file())
+        {
+            continue;
+        }
+
+        const std::string filename = entry.path().filename().string();
+        const auto [type, suffix] = eloqstore::ParseFileName(filename);
+        (void) suffix;
+        if (type == eloqstore::FileNameData)
+        {
+            files.push_back(filename);
+        }
+    }
+    std::sort(files.begin(), files.end());
+    return files;
+}
+
+void ReadOneKey(eloqstore::EloqStore &store,
+                const eloqstore::TableIdent &tbl_id,
+                uint64_t key)
+{
+    eloqstore::ReadRequest req;
+    req.SetArgs(tbl_id, Key(key));
+    store.ExecSync(&req);
+    REQUIRE(req.Error() == eloqstore::KvError::NoError);
+}
+
+void RunStandbyProcessHelper()
+{
+    const fs::path self_path = fs::read_symlink("/proc/self/exe");
+    auto quote = [](std::string_view value)
+    {
+        std::string out = "\"";
+        out.append(value);
+        out.push_back('"');
+        return out;
+    };
+    std::ostringstream cmd;
+    cmd << quote(self_path.string()) << ' ' << quote("[standby-subproc]");
+    REQUIRE(std::system(cmd.str().c_str()) == 0);
+}
 }  // namespace
+
+TEST_CASE("standby subprocess master writer", "[.][standby-subproc]")
+{
+    const fs::path temp_root =
+        fs::temp_directory_path() / std::string(kStaleManifestTempRootName);
+    const fs::path master_dir = temp_root / "master";
+
+    eloqstore::KvOptions opts = cloud_options;
+    opts.store_path = {master_dir.string()};
+    opts.cloud_store_path = cloud_options.cloud_store_path + "/" +
+                            std::string(kStaleManifestTempRootName);
+    opts.allow_reuse_local_caches = true;
+    opts.pages_per_file_shift = 1;
+
+    const eloqstore::TableIdent tbl_id{std::string(kStaleManifestTableName), 0};
+
+    eloqstore::EloqStore store(opts);
+    REQUIRE(store.Start("main", 1) == eloqstore::KvError::NoError);
+    UpsertRange(
+        store, tbl_id, kStaleManifestPhaseBegin, kStaleManifestPhaseEnd);
+    store.Stop();
+}
 
 TEST_CASE("standby reopen a partition with nonexistent dir", "[standby]")
 {
@@ -110,6 +255,7 @@ TEST_CASE("standby reopen a partition with nonexistent dir", "[standby]")
     opts.pages_per_file_shift = 0;
 
     eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+    const fs::path partition_path = local_dir / tbl_id.ToString();
 
     eloqstore::EloqStore store(opts);
     REQUIRE(store.Start("main", 1) == eloqstore::KvError::NoError);
@@ -127,6 +273,8 @@ TEST_CASE("standby reopen a partition with nonexistent dir", "[standby]")
     REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
 
     VerifyRange(standby, tbl_id, 0, 5000, false);
+    REQUIRE(WaitForCondition(
+        5s, 100ms, [&]() { return !fs::exists(partition_path); }));
 
     standby.Stop();
 
@@ -140,6 +288,7 @@ TEST_CASE("standby reopen a partition with empty dir", "[standby]")
     fs::path local_dir = dir / "local";
 
     eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+    const fs::path partition_path = local_dir / tbl_id.ToString();
 
     fs::remove_all(dir);
     fs::create_directories(remote_master_dir / tbl_id.ToString());
@@ -167,7 +316,86 @@ TEST_CASE("standby reopen a partition with empty dir", "[standby]")
     REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
 
     VerifyRange(standby, tbl_id, 0, 5000, false);
+    REQUIRE(WaitForCondition(
+        5s, 100ms, [&]() { return !fs::exists(partition_path); }));
 
+    standby.Stop();
+
+    fs::remove_all(dir);
+}
+
+TEST_CASE("standby reopen without tag with nonexistent dir", "[standby]")
+{
+    fs::path dir =
+        fs::temp_directory_path() / fs::path("standby-latest-missing-test");
+    fs::path remote_master_dir = dir / "remote-master";
+    fs::path local_dir = dir / "local";
+    fs::remove_all(dir);
+    fs::create_directories(local_dir);
+    fs::create_directories(remote_master_dir);
+
+    eloqstore::KvOptions opts;
+    opts.store_path = {local_dir.string()};
+    opts.enable_local_standby = true;
+    opts.standby_master_store_paths = {};
+    opts.pages_per_file_shift = 0;
+
+    eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+    const fs::path partition_path = local_dir / tbl_id.ToString();
+
+    eloqstore::EloqStore store(opts);
+    REQUIRE(store.Start("main", 1) == eloqstore::KvError::NoError);
+    UpsertRange(store, tbl_id, 0, 5000);
+    VerifyRange(store, tbl_id, 0, 5000, true);
+    store.Stop();
+
+    opts.standby_master_addr = "local";
+    opts.standby_master_store_paths = {remote_master_dir.string()};
+    eloqstore::EloqStore standby(opts);
+    REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+    ReopenStore(standby);
+    VerifyRange(standby, tbl_id, 0, 5000, false);
+    REQUIRE(WaitForCondition(
+        5s, 100ms, [&]() { return !fs::exists(partition_path); }));
+    standby.Stop();
+
+    fs::remove_all(dir);
+}
+
+TEST_CASE("standby reopen without tag with empty dir", "[standby]")
+{
+    fs::path dir =
+        fs::temp_directory_path() / fs::path("standby-latest-empty-test");
+    fs::path remote_master_dir = dir / "remote-master";
+    fs::path local_dir = dir / "local";
+
+    eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+    const fs::path partition_path = local_dir / tbl_id.ToString();
+
+    fs::remove_all(dir);
+    fs::create_directories(remote_master_dir / tbl_id.ToString());
+    fs::create_directories(local_dir);
+
+    eloqstore::KvOptions opts;
+    opts.store_path = {local_dir.string()};
+    opts.enable_local_standby = true;
+    opts.standby_master_store_paths = {};
+    opts.pages_per_file_shift = 0;
+
+    eloqstore::EloqStore store(opts);
+    REQUIRE(store.Start("main", 1) == eloqstore::KvError::NoError);
+    UpsertRange(store, tbl_id, 0, 5000);
+    VerifyRange(store, tbl_id, 0, 5000, true);
+    store.Stop();
+
+    opts.standby_master_addr = "local";
+    opts.standby_master_store_paths = {remote_master_dir.string()};
+    eloqstore::EloqStore standby(opts);
+    REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+    ReopenStore(standby);
+    VerifyRange(standby, tbl_id, 0, 5000, false);
+    REQUIRE(WaitForCondition(
+        5s, 100ms, [&]() { return !fs::exists(partition_path); }));
     standby.Stop();
 
     fs::remove_all(dir);
@@ -492,6 +720,219 @@ TEST_CASE("standby rsync replica follows master changes", "[standby]")
     fs::remove_all(temp_root);
 }
 
+TEST_CASE("standby reopen without tag follows latest master manifest",
+          "[standby]")
+{
+    fs::path temp_root =
+        fs::temp_directory_path() / fs::path("standby-latest-test");
+    fs::path master_dir = temp_root / "master";
+    fs::path standby_dir = temp_root / "standby";
+    fs::remove_all(temp_root);
+    fs::create_directories(master_dir);
+    fs::create_directories(standby_dir);
+
+    eloqstore::KvOptions master_opts;
+    master_opts.store_path = {master_dir.string()};
+    master_opts.enable_local_standby = true;
+    master_opts.standby_master_store_paths = {};
+    master_opts.pages_per_file_shift = 0;
+
+    eloqstore::KvOptions standby_opts;
+    standby_opts.store_path = {standby_dir.string()};
+    standby_opts.enable_local_standby = true;
+    standby_opts.standby_master_addr = "local";
+    standby_opts.standby_master_store_paths = {master_dir.string()};
+    standby_opts.pages_per_file_shift = 0;
+
+    eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+
+    {
+        eloqstore::EloqStore master(master_opts);
+        REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
+        UpsertRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, true);
+        master.Stop();
+    }
+
+    {
+        eloqstore::EloqStore standby(standby_opts);
+        REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+
+        eloqstore::GlobalReopenRequest reopen_req;
+        standby.ExecSync(&reopen_req);
+        REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
+
+        VerifyRange(standby, tbl_id, 0, 5000, true);
+
+        standby.Stop();
+    }
+
+    {
+        eloqstore::EloqStore master(master_opts);
+        REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
+
+        DeleteRange(master, tbl_id, 0, 2500);
+        UpsertRange(master, tbl_id, 5000, 7500);
+
+        VerifyRange(master, tbl_id, 0, 2500, false);
+        VerifyRange(master, tbl_id, 2500, 5000, true);
+        VerifyRange(master, tbl_id, 5000, 7500, true);
+
+        master.Stop();
+    }
+
+    {
+        eloqstore::EloqStore standby(standby_opts);
+        REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+
+        // Load current state before reopening to latest to exercise online
+        // reopen against an already-open replica.
+        Scan(&standby, tbl_id, 0, 8000);
+
+        eloqstore::GlobalReopenRequest reopen_req;
+        standby.ExecSync(&reopen_req);
+        REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
+
+        VerifyRange(standby, tbl_id, 0, 2500, false);
+        VerifyRange(standby, tbl_id, 2500, 5000, true);
+        VerifyRange(standby, tbl_id, 5000, 7500, true);
+
+        standby.Stop();
+    }
+
+    fs::remove_all(temp_root);
+}
+
+TEST_CASE(
+    "standby reopen without tag loads latest master data into empty standby",
+    "[standby]")
+{
+    fs::path dir =
+        fs::temp_directory_path() / fs::path("standby-latest-empty-load-test");
+    fs::path master_dir = dir / "master";
+    fs::path standby_dir = dir / "standby";
+    fs::remove_all(dir);
+    fs::create_directories(master_dir);
+    fs::create_directories(standby_dir);
+
+    eloqstore::KvOptions master_opts;
+    master_opts.store_path = {master_dir.string()};
+    master_opts.enable_local_standby = true;
+    master_opts.standby_master_store_paths = {};
+    master_opts.pages_per_file_shift = 0;
+
+    eloqstore::KvOptions standby_opts = master_opts;
+    standby_opts.store_path = {standby_dir.string()};
+    standby_opts.standby_master_addr = "local";
+    standby_opts.standby_master_store_paths = {master_dir.string()};
+
+    eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+
+    {
+        eloqstore::EloqStore master(master_opts);
+        REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
+        UpsertRange(master, tbl_id, 0, 5000);
+        VerifyRange(master, tbl_id, 0, 5000, true);
+        master.Stop();
+    }
+
+    {
+        eloqstore::EloqStore standby(standby_opts);
+        REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+        ReopenStore(standby);
+        VerifyRange(standby, tbl_id, 0, 5000, true);
+        standby.Stop();
+    }
+
+    fs::remove_all(dir);
+}
+
+TEST_CASE(
+    "standby rsync replica without tag follows master changes and term switch",
+    "[standby]")
+{
+    fs::path temp_root =
+        fs::temp_directory_path() / fs::path("standby-latest-term-test");
+    fs::path master_dir = temp_root / "master";
+    fs::path new_master_dir = temp_root / "new_master";
+    fs::path standby_dir = temp_root / "standby";
+    fs::remove_all(temp_root);
+    fs::create_directories(master_dir);
+    fs::create_directories(standby_dir);
+
+    eloqstore::KvOptions master_opts;
+    master_opts.store_path = {master_dir.string()};
+    master_opts.enable_local_standby = true;
+    master_opts.standby_master_store_paths = {};
+    master_opts.pages_per_file_shift = 0;
+
+    eloqstore::KvOptions new_master_opts = master_opts;
+    new_master_opts.store_path = {new_master_dir.string()};
+
+    eloqstore::KvOptions standby_opts;
+    standby_opts.store_path = {standby_dir.string()};
+    standby_opts.enable_local_standby = true;
+    standby_opts.standby_master_addr = "local";
+    standby_opts.standby_master_store_paths = {master_dir.string()};
+    standby_opts.pages_per_file_shift = 0;
+
+    eloqstore::TableIdent tbl_id{"standby_tbl", 0};
+    const fs::path partition_path = standby_dir / tbl_id.ToString();
+
+    {
+        eloqstore::EloqStore master(master_opts);
+        REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
+        UpsertRange(master, tbl_id, 0, 5000);
+        master.Stop();
+    }
+
+    {
+        eloqstore::EloqStore standby(standby_opts);
+        REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+        ReopenStore(standby);
+        VerifyRange(standby, tbl_id, 0, 5000, true);
+        standby.Stop();
+    }
+
+    {
+        eloqstore::EloqStore master(master_opts);
+        REQUIRE(master.Start("main", 1) == eloqstore::KvError::NoError);
+        DeleteRange(master, tbl_id, 0, 5000);
+        master.Stop();
+    }
+
+    {
+        eloqstore::EloqStore standby(standby_opts);
+        REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+        Scan(&standby, tbl_id, 0, 10000);
+        ReopenStore(standby);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
+        REQUIRE(WaitForCondition(
+            10s, 100ms, [&]() { return !fs::exists(partition_path); }));
+        standby.Stop();
+    }
+
+    {
+        eloqstore::EloqStore new_master(new_master_opts);
+        REQUIRE(new_master.Start("main", 2) == eloqstore::KvError::NoError);
+        UpsertRange(new_master, tbl_id, 5001, 10000);
+        new_master.Stop();
+    }
+
+    {
+        standby_opts.standby_master_store_paths = {new_master_dir.string()};
+        eloqstore::EloqStore standby(standby_opts);
+        REQUIRE(standby.Start("main", 2) == eloqstore::KvError::NoError);
+        Scan(&standby, tbl_id, 0, 10000);
+        ReopenStore(standby);
+        VerifyRange(standby, tbl_id, 0, 5000, false);
+        VerifyRange(standby, tbl_id, 5001, 10000, true);
+        standby.Stop();
+    }
+
+    fs::remove_all(temp_root);
+}
+
 TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
 {
     fs::path temp_root = fs::temp_directory_path() / "standby-cloud-test";
@@ -500,20 +941,20 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
     fs::path standby_dir = temp_root / "standby";
     fs::remove_all(temp_root);
 
-    std::string cloud_storage_path = cloud_archive_opts.cloud_store_path + "/" +
-                                     temp_root.filename().string();
+    std::string cloud_storage_path =
+        cloud_options.cloud_store_path + "/" + temp_root.filename().string();
 
-    eloqstore::KvOptions master_opts = cloud_archive_opts;
+    eloqstore::KvOptions master_opts = cloud_options;
     master_opts.store_path = {master_dir.string()};
     master_opts.cloud_store_path = cloud_storage_path;
     master_opts.allow_reuse_local_caches = true;
-    master_opts.pages_per_file_shift = 0;
+    master_opts.pages_per_file_shift = 1;
 
     eloqstore::KvOptions standby_opts = cloud_archive_opts;
     standby_opts.store_path = {standby_dir.string()};
     standby_opts.cloud_store_path = cloud_storage_path;
     standby_opts.allow_reuse_local_caches = true;
-    standby_opts.pages_per_file_shift = 0;
+    standby_opts.pages_per_file_shift = 1;
 
     eloqstore::KvOptions new_master_opts = master_opts;
     new_master_opts.store_path = {new_master_dir.string()};
@@ -587,42 +1028,6 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
         reopen_req.SetTag(std::to_string(2002));
         standby.ExecSync(&reopen_req);
         REQUIRE(reopen_req.Error() == eloqstore::KvError::NoError);
-        REQUIRE(WaitForCondition(
-            10s,
-            100ms,
-            [&]()
-            {
-                if (!fs::exists(partition_path))
-                {
-                    return false;
-                }
-
-                bool has_manifest = false;
-                for (const auto &entry : fs::directory_iterator(partition_path))
-                {
-                    if (!entry.is_regular_file())
-                    {
-                        continue;
-                    }
-
-                    const std::string filename =
-                        entry.path().filename().string();
-                    const auto parsed = eloqstore::ParseFileName(filename);
-                    const auto &type = parsed.first;
-                    if (type == eloqstore::FileNameManifest)
-                    {
-                        has_manifest = true;
-                        continue;
-                    }
-
-                    if (type == eloqstore::FileNameData)
-                    {
-                        return false;
-                    }
-                }
-
-                return has_manifest;
-            }));
 
         eloqstore::ReadRequest read_req;
         read_req.SetArgs(tbl_id, Key(0));
@@ -717,5 +1122,138 @@ TEST_CASE("standby replica follows cloud-mode master", "[standby][cloud]")
     CleanupStore(master_opts);
     CleanupStore(standby_opts);
     CleanupStore(new_master_opts);
+    fs::remove_all(temp_root);
+}
+
+TEST_CASE(
+    "standby cloud scan succeeds via auto reopen after stale local manifest "
+    "and cloud gc",
+    "[standby][cloud][gc]")
+{
+    constexpr uint64_t kPhase2Rounds = 3;
+
+    fs::path temp_root =
+        fs::temp_directory_path() / std::string(kStaleManifestTempRootName);
+    fs::path master_dir = temp_root / "master";
+    fs::path standby_dir = temp_root / "standby";
+    fs::remove_all(temp_root);
+
+    std::string cloud_storage_path =
+        cloud_options.cloud_store_path + "/" + temp_root.filename().string();
+
+    eloqstore::KvOptions master_opts = cloud_options;
+    master_opts.store_path = {master_dir.string()};
+    master_opts.cloud_store_path = cloud_storage_path;
+    master_opts.allow_reuse_local_caches = true;
+    master_opts.pages_per_file_shift = 1;
+
+    eloqstore::KvOptions standby_opts = master_opts;
+    standby_opts.store_path = {standby_dir.string()};
+
+    CleanupStore(master_opts);
+    CleanupStore(standby_opts);
+
+    const eloqstore::TableIdent tbl_id{std::string(kStaleManifestTableName), 0};
+    const fs::path standby_partition_path = standby_dir / tbl_id.ToString();
+    std::vector<std::string> old_cloud_data_files;
+
+    RunStandbyProcessHelper();
+    old_cloud_data_files = ListDataFiles(ListCloudFiles(
+        master_opts, master_opts.cloud_store_path, tbl_id.ToString()));
+    std::sort(old_cloud_data_files.begin(), old_cloud_data_files.end());
+    REQUIRE_FALSE(old_cloud_data_files.empty());
+
+    CleanupLocalStore(standby_opts);
+    eloqstore::EloqStore standby(standby_opts);
+    REQUIRE(standby.Start("main", 1) == eloqstore::KvError::NoError);
+
+    ReopenStore(standby);
+    ReadOneKey(standby, tbl_id, kStaleManifestPhaseBegin);
+    const auto local_data_files = ListLocalDataFiles(standby_partition_path);
+    REQUIRE_FALSE(local_data_files.empty());
+    REQUIRE(local_data_files.size() < old_cloud_data_files.size());
+
+    std::vector<std::string> old_remote_only_files;
+    std::set_difference(old_cloud_data_files.begin(),
+                        old_cloud_data_files.end(),
+                        local_data_files.begin(),
+                        local_data_files.end(),
+                        std::back_inserter(old_remote_only_files));
+    REQUIRE_FALSE(old_remote_only_files.empty());
+
+    REQUIRE(fs::exists(standby_partition_path));
+    RemoveLocalNonManifestFiles(standby_partition_path);
+
+    bool has_local_manifest = false;
+    bool has_non_manifest_file = false;
+    for (const auto &entry : fs::directory_iterator(standby_partition_path))
+    {
+        if (!entry.is_regular_file())
+        {
+            continue;
+        }
+
+        const std::string filename = entry.path().filename().string();
+        const auto [type, suffix] = eloqstore::ParseFileName(filename);
+        (void) suffix;
+        std::string_view branch_name;
+        const bool is_current_term =
+            eloqstore::ParseCurrentTermFilename(filename, branch_name);
+        if (type == eloqstore::FileNameManifest)
+        {
+            has_local_manifest = true;
+        }
+        else if (!is_current_term)
+        {
+            has_non_manifest_file = true;
+        }
+    }
+    REQUIRE(has_local_manifest);
+    REQUIRE_FALSE(has_non_manifest_file);
+
+    bool removed_old_remote_only_file = false;
+    for (uint64_t round = 0;
+         round < kPhase2Rounds && !removed_old_remote_only_file;
+         ++round)
+    {
+        RunStandbyProcessHelper();
+
+        removed_old_remote_only_file = WaitForCondition(
+            15s,
+            100ms,
+            [&]()
+            {
+                auto refreshed_cloud_data_files =
+                    ListDataFiles(ListCloudFiles(master_opts,
+                                                 master_opts.cloud_store_path,
+                                                 tbl_id.ToString()));
+                if (refreshed_cloud_data_files.empty())
+                {
+                    return false;
+                }
+                std::sort(refreshed_cloud_data_files.begin(),
+                          refreshed_cloud_data_files.end());
+
+                return std::any_of(old_remote_only_files.begin(),
+                                   old_remote_only_files.end(),
+                                   [&](const std::string &filename)
+                                   {
+                                       return !std::binary_search(
+                                           refreshed_cloud_data_files.begin(),
+                                           refreshed_cloud_data_files.end(),
+                                           filename);
+                                   });
+            });
+    }
+    REQUIRE(removed_old_remote_only_file);
+
+    const eloqstore::KvError scan_err = ScanRange(
+        standby, tbl_id, kStaleManifestPhaseBegin, kStaleManifestPhaseEnd);
+    REQUIRE(scan_err == eloqstore::KvError::NoError);
+
+    standby.Stop();
+
+    CleanupStore(master_opts);
+    CleanupStore(standby_opts);
     fs::remove_all(temp_root);
 }


### PR DESCRIPTION
  This change introduces an auto-reopen retry path for requests that fail with ResourceMissing relative to main. The goal
  is to treat ResourceMissing as “the requested backing resource should exist, but is temporarily missing or stale”, then
  reopen the table state and retry the original request instead of failing immediately.

  Changes:

  - Add ResourceMissing-driven auto-reopen retry handling for cloud and standby requests
  - Initialize reopen_retry_remaining_ in ExecSync() and ExecAsyn()
  - Defer auto-reopen scheduling until the original task has fully finished, instead of triggering it from
    KvRequest::SetDone()
  - Queue a per-table internal ReopenRequest and resubmit waiting requests after reopen completes
  - Keep KvRequest::SetDone() as a pure completion path
  - Add minimal task state with needs_auto_reopen_ to carry retry intent across coroutine completion

  Why:

  - Relative to main, this PR adds the new ResourceMissing -> reopen -> retry mechanism
  - Triggering reopen directly inside SetDone() caused request lifecycle issues because the original coroutine had not
    fully finished yet
  - Moving the retry handoff to OnTaskFinished() preserves write-task ordering and avoids hanging or reentrant request
    state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable automatic reopen retries for cloud/standby modes (default 10) to help transparently recover from transient missing resources.

* **Bug Fixes**
  * Introduced a distinct "ResourceMissing" condition and updated flows to treat missing remote manifests/files gracefully (defer/retry instead of hard-failing).
  * Standby rsync/manifest handling now accepts empty tags and resolves to the latest master manifest.

* **Tests**
  * Expanded standby, reopen, and cloud GC tests covering reopen-without-tag and stale-manifest scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->