### PR TITLE
chore: set unlimit memlock in github ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       CCACHE_MAXSIZE: 1G
     container:
       image: eloqdata/eloq-dev-ci-ubuntu2404:latest
-      options: --user root --security-opt seccomp=unconfined
+      options: --user root --security-opt seccomp=unconfined --ulimit memlock=-1:-1
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline to allow unlimited locked memory, increasing memory resource limits to improve build and test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->