### PR TITLE
[codex] build: support data substrate third-party workspace

### DIFF
--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -49,6 +49,7 @@
 
 #include <butil/time.h>
 
+#include "absl/strings/string_view.h"
 #include "cloud_storage_service.h"
 #include "coding.h"
 #include "common.h"
@@ -1875,12 +1876,13 @@ void IouringMgr::RollbackBranchFileTail(const TableIdent &tbl_id,
 
 std::string_view IouringMgr::InternBranchName(std::string_view name)
 {
-    auto it = branch_name_pool_.find(name);
+    absl::string_view absl_name(name.data(), name.size());
+    auto it = branch_name_pool_.find(absl_name);
     if (it != branch_name_pool_.end())
     {
         return *it;
     }
-    auto [inserted_it, inserted] = branch_name_pool_.emplace(name);
+    auto [inserted_it, inserted] = branch_name_pool_.emplace(std::string(name));
     return *inserted_it;
 }
 

--- a/src/file_gc.cpp
+++ b/src/file_gc.cpp
@@ -16,6 +16,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/strings/string_view.h"
 #include "async_io_manager.h"
 #include "common.h"
 #include "eloq_store.h"
@@ -985,7 +986,8 @@ KvError DeleteUnreferencedCloudFiles(
         // its manifest was dropped/reopened and the unretained file can be
         // deleted. For other branches, missing guard means we do not have a
         // flushed boundary, so preserve the file conservatively.
-        auto it = branch_guards.find(branch_name);
+        absl::string_view absl_branch(branch_name.data(), branch_name.size());
+        auto it = branch_guards.find(absl_branch);
         if (it == branch_guards.end())
         {
             if (branch_name != active_branch)
@@ -1189,7 +1191,8 @@ KvError DeleteUnreferencedLocalFiles(
         // its manifest was dropped/reopened and the unretained file can be
         // deleted. For other branches, missing guard means we do not have a
         // flushed boundary, so preserve the file conservatively.
-        auto it = branch_guards.find(branch_name);
+        absl::string_view absl_branch(branch_name.data(), branch_name.size());
+        auto it = branch_guards.find(absl_branch);
         if (it == branch_guards.end())
         {
             if (branch_name != io_mgr->GetActiveBranch())
@@ -1312,7 +1315,8 @@ KvError DeleteUnreferencedLocalSegmentFiles(
         // In-flight write guard. Missing guard keeps non-active branches
         // conservative, but does not protect the active branch after its
         // manifest was dropped/reopened.
-        auto it = branch_guards.find(branch_name);
+        absl::string_view absl_branch(branch_name.data(), branch_name.size());
+        auto it = branch_guards.find(absl_branch);
         if (it == branch_guards.end())
         {
             if (branch_name != io_mgr->GetActiveBranch())
@@ -1432,7 +1436,8 @@ KvError DeleteUnreferencedCloudSegmentFiles(
         // In-flight write guard. Mirrors the data-file path's missing-guard
         // handling: active branch can be collected, non-active branches are
         // preserved conservatively.
-        auto it = branch_guards.find(branch_name);
+        absl::string_view absl_branch(branch_name.data(), branch_name.size());
+        auto it = branch_guards.find(absl_branch);
         if (it == branch_guards.end())
         {
             if (branch_name != cloud_mgr->GetActiveBranch())


### PR DESCRIPTION
## Summary
- Fix Abseil string-view lookup compatibility in eloqstore when Abseil is built with its own string_view type.
- Keep heterogeneous lookup explicit by converting std::string_view to absl::string_view before querying the Abseil flat hash container.

## Validation
- Verified as part of a clean Ubuntu 24.04 clone/build of eloqkv at dbf047fc689e.
- Commands passed: scripts/checkout_product_submodules.sh, scripts/install_dependency_ubuntu2404.sh, cmake configure, make -j$(nproc).

## Notes
- This is the leaf PR for the data_substrate/eloqkv third-party workspace cascade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch-name handling for asynchronous I/O, making branch lookups more consistent and reliable.
  * Tightened cache behavior so interned branch-name lookups reuse stable stored values rather than transient views.
  * Updated garbage-collection branch-guard lookups to use consistent string-view inputs, improving correctness across cloud and local deletion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->