### PR TITLE
docs: add maintained architecture documentation and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+EloqStore is a hybrid-tier key-value storage engine in C++20: in-memory B-tree index (hot), local NVMe via io_uring (warm), S3-compatible object storage (cold). It uses a copy-on-write B-tree so batch writes never block reads. Requires Linux kernel 6.8+ (io_uring) and `rsync` (standby replication and tests).
+
+## Architecture docs — read these first, keep them updated
+
+`docs/architecture/` is the maintained design documentation (its `README.md` is the index). Before working on a subsystem, read `01-overview.md` plus the doc covering that subsystem — it is much faster than re-deriving the design from source, and it records invariants the code only implies. **When a code change alters behavior described in those docs (request types, manifest/page formats, KvOptions fields, GC rules, lifecycle ordering, renamed classes), update the matching doc in the same change.** Each doc lists the source files it covers. Prefer `docs/architecture/` over `.codex/knowledge-base/` (stale) and over `docs/zero_copy_*.md` (original design proposals, partially superseded).
+
+## Build
+
+```bash
+# One-time dependency install (Ubuntu 24.04, needs sudo)
+bash scripts/install_dependency_ubuntu2404.sh
+
+# Configure + build (SKIP_CREATE_BUCKET=ON is what CI uses for unit tests)
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DSKIP_CREATE_BUCKET=ON
+cmake --build build -j$(nproc)
+```
+
+Useful CMake options: `WITH_ASAN=ON` (needs `libboost_context-asan`), `WITH_COVERAGE=ON`, `ELOQ_MODULE_ENABLED=ON` (embedding/module mode), `WITH_UNIT_TESTS`/`WITH_EXAMPLE`/`WITH_DB_STRESS`/`WITH_BENCHMARK` (all default ON). Compile commands are exported to `build/` and `.clangd` points there.
+
+CMake configure runs `git submodule update --init --recursive` automatically (submodules live in `external/`).
+
+## Tests
+
+Cloud-mode tests need MinIO running on `127.0.0.1:9900` first:
+
+```bash
+wget https://dl.min.io/server/minio/release/linux-amd64/minio && chmod +x minio
+./minio server /tmp/minio-data --address :9900 --console-address :9901
+```
+
+```bash
+# All tests
+ctest --test-dir build/tests/ --output-on-failure
+
+# Each tests/*.cpp builds into its own Catch2 executable in build/tests/.
+# Run one binary, or one test case by name / tag:
+./build/tests/batch_write
+./build/tests/batch_write "mixed batch write with read"
+./build/tests/scan "[scan]"
+# Or via ctest regex:
+ctest --test-dir build/tests/ -R "complex scan"
+```
+
+The `large_value_*` and `segment_compact` tests register io_uring fixed buffers and need RLIMIT_MEMLOCK ≥ 2GB. Their custom main (`tests/large_value_main.cpp`) bumps the limit best-effort; CI runs with `--ulimit memlock=-1:-1`. Under WSL2 use `systemd-run --user --pipe --wait --property=LimitMEMLOCK=2G ./build/tests/large_value_e2e`.
+
+Test fixtures: `tests/common.h` defines the canonical `KvOptions` presets (`default_opts`, `append_opts`, `cloud_options`, ...) plus S3 helpers; local data goes under `/tmp/eloqstore` or `/tmp/test-data`, and `CleanupStore()` wipes both local and MinIO state.
+
+SDK tests (also run in CI): `python3 -m build --wheel` + pytest in `python/`; in `rust/`: `cargo test -p eloqstore --test integration_test -- --nocapture --test-threads=1`.
+
+## Formatting
+
+`bash scripts/format.sh` — installs clang-format 18.1.8 on first run and formats the tree. Main branch has a format check in CI; run before committing. Style is Google-based with Allman braces, 4-space indent, right pointer alignment (see `.clang-format`).
+
+## Architecture
+
+Full subsystem documentation lives in `docs/architecture/` (see above). The load-bearing invariants, as a quick reference:
+
+**EloqStore is the root owner** (`include/eloq_store.h`, `src/eloq_store.cpp`). `EloqStore::Start` derives one `StoreMode` from `KVOptions` — cloud (cloud bucket set), standby replica (standby remote path set), standby master (standalone replication), else local — and that choice fixes the whole topology: which `AsyncIoManager` backend is built, whether `CloudStorageService`/`StandbyService` exist, which options are legal. Startup is dependency-ordered (options → store-space metadata → shards → remote services → shard execution → archive/prewarm); shutdown is the exact inverse so late completions never touch freed state.
+
+**Shard-thread affinity replaces locking.** Each shard owns one worker thread and event loop. Requests become pooled `KvTask` subclasses (`TaskManager`) running as `boost::context` coroutines; `Resume`/`Yield`/`WaitIo`/`FinishIo` are the handoff points. All async completions — including cloud and standby ones arriving on service threads — must re-enter through the shard's ready queues, never resume a task on a foreign thread. Per-table write serialization and write-concurrency limits are enforced in `TaskManager` above the coroutine layer. In module mode (`EloqStoreModule`) the embedding runtime drives shard progress via one-round `Process`/`HasTask` calls instead of dedicated threads.
+
+**Request surface** (`include/eloq_store.h`): `KvRequest` subclasses with `ExecSync`/`ExecAsyn`; `SetDone()` is the single completion gate (callback OR sync wake, never both). `KvRequest::ReadOnly()` depends on enum ordering (`Type() < RequestType::BatchWrite`) — don't reorder `RequestType`. Global requests (`DropTable`, `GlobalArchive`, `GlobalReopen`) fan out into per-partition subrequests at the store level; everything else routes to `shards_[TableId().ShardIndex(...)]`. Borrowed `string_view` request inputs must outlive completion.
+
+**I/O stack is layered, not parallel implementations** (`include/async_io_manager.h`): `IouringMgr` is the local-filesystem base (page buffers, manifests, FD cache, direct I/O, merged writes); `CloudStoreMgr` extends it, treating local files as a cache over object storage (`ObjectStore` → `CloudStorageService` → `AsyncHttpManager`); `StandbyStoreMgr` extends it filling missing state via rsync jobs in `StandbyService`. Local manifest/page semantics are the common substrate in every mode — remote sync and cache cleanup must preserve local replayability.
+
+**On-disk and in-memory page formats intentionally differ** (`src/storage/`). `DataPageBuilder`/`IndexPageBuilder` define the canonical encoded layout (prefix-compressed keys, restart points, timestamp deltas, overflow flags); large values go to chained overflow pages. In memory, internal nodes are swizzled `MemIndexPage` objects with pins and cached child pointers, managed by `IndexPageManager`. Any file-format change must update both builder and reader paths.
+
+**Durability is anchored at RootMeta + manifest, not pages** (`src/storage/root_meta.cpp`, `src/storage/page_mapper.cpp`, `src/replayer.cpp`). Logical-to-file page identity is versioned through `MappingSnapshot`s for COW root transitions; `PageMapper` owns the logical page table and allocator, reconstructed from manifest replay. `Replayer` handles both cold restart and live refresh (reopen, cloud/standby snapshot install) — manifest encoding changes must keep both working. Swizzled pages can only be recycled after being unswizzled from every live mapping snapshot.
+
+**Bindings stack** (one-way dependency onto the native engine): `ffi/` C ABI (`eloqstore_capi`, opaque handles, explicit free functions) → `rust/eloqstore-sys` (raw FFI) → `rust/eloqstore` (high-level API); `python/` SDK also wraps the C ABI. Bindings adapt API shape but must not invent a different lifecycle, completion, or ownership model.
+
+## CI notes
+
+PRs need the `ci-approved` label for CI to run (`.github/workflows/ci.yml`). CI builds Debug with `SKIP_CREATE_BUCKET=ON`, runs C++ tests against MinIO, then builds/tests the Python wheel and Rust SDK.

--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -1,0 +1,86 @@
+# Overview
+
+EloqStore is an embeddable, persistent key-value storage engine written in
+C++20. It is a *library*, not a server: the embedding application (EloqKV,
+EloqDoc, EloqSQL, the Rust/Python SDKs, or the data-store service) constructs
+an `eloqstore::EloqStore`, starts it, and submits request objects to it.
+
+Design goals, in priority order:
+
+1. **Predictable point-read latency on flash** — every point read on cold data
+   costs exactly one disk I/O, because all B+-tree index (non-leaf) pages are
+   kept in memory and only leaf/data pages live on disk.
+2. **High-throughput batch writes without blocking reads** — the tree is
+   copy-on-write (CoW); a batch write builds new pages and publishes a new
+   root, while concurrent readers keep traversing the old root.
+3. **Object storage as primary storage** — in cloud mode, S3-compatible object
+   storage holds the durable copy and the local disk is just a cache.
+
+## Core concepts and glossary
+
+| Term | Meaning |
+|------|---------|
+| **Partition** | The unit of data and of write serialization. Identified by `TableIdent {tbl_name_, partition_id_}` (`include/types.h`). Each partition is an independent B+-tree with its own manifest, files, and directory `<store_path>/<tbl_name>.<partition_id>/`. |
+| **Shard** | The unit of execution. One shard = one worker thread + one io_uring + one set of caches (`include/storage/shard.h`). `KvOptions::num_threads` sets the shard count. A partition is statically routed to shard `TableIdent::ShardIndex(num_shards)` (hash). |
+| **Page** | 4 KiB (configurable `data_page_size`) aligned buffer; the B+-tree node unit. Types: non-leaf index, leaf index, data (leaf), overflow (`include/storage/page.h`). |
+| **PageId / FilePageId** | `PageId` is a partition-local *logical* page number; `FilePageId` is the *physical* location (file id × pages-per-file + offset). The indirection table between them is the page mapping (doc 06). |
+| **Segment** | Large (default 256 KiB) append-only allocation unit for very-large values, stored in dedicated *segment files* (doc 09). |
+| **Manifest** | Per-partition redo log of metadata: tree roots + page mapping snapshot + appended deltas. Replayed on open (doc 06). |
+| **Term** | Monotonic ownership epoch supplied by the embedding system (e.g. raft term). File names embed the term that wrote them; in cloud mode a `CURRENT_TERM_<branch>_<pg_id>` object fences stale writers (doc 06). |
+| **Branch** | A named fork of a partition's data (`MainBranchName = "main"`). Branches share immutable files with their parent via `BranchFileMapping` file-range bookkeeping; used for instant data forks (doc 06). |
+| **Archive** | A retained manifest snapshot (`manifest_<branch>_<term>_<tag>`) that pins the set of files needed to reopen the partition at that point in time (docs 06, 08). |
+| **Request / Task** | Callers submit `KvRequest` objects (doc 03); shards execute them as pooled `KvTask` coroutines (doc 04). |
+
+## Store modes
+
+`DeriveStoreMode(opts)` in `include/eloq_store.h` picks exactly one mode at
+`Start()`:
+
+| Mode | Selected when | Backing |
+|------|---------------|---------|
+| `Local` | default | Local files via io_uring (`IouringMgr`); or pure in-memory (`MemStoreMgr`) when `store_path` is empty |
+| `Cloud` | `cloud_store_path` non-empty | S3-compatible object store is durable; local disk is an LRU cache (`CloudStoreMgr`) |
+| `StandbyMaster` | `enable_local_standby` and no `standby_master_addr` | Local mode that allows replicas to rsync from it |
+| `StandbyReplica` | `enable_local_standby` + `standby_master_addr` | Pulls manifests/files from the master over rsync on demand (`StandbyStoreMgr`) |
+
+The mode decides which `AsyncIoManager` subclass each shard gets, which
+auxiliary services exist (`CloudStorageService`, `StandbyService`,
+`PrewarmService`, `ArchiveCrond`), and which option combinations are legal
+(doc 02, 07).
+
+## Write modes
+
+Independent of store mode, `KvOptions::data_append_mode` selects how data
+pages map to files:
+
+- **Append mode (`true`)** — pages are always written to the end of the newest
+  data file (`AppendAllocator`); rewritten pages leave holes that background
+  compaction reclaims. Required pattern for cloud mode (files become immutable
+  objects once sealed) and for archives/branches.
+- **In-place mode (`false`)** — file pages are recycled from a free pool
+  (`PooledFilePages`); fewer files, no compaction, but files mutate in place.
+
+## Repository layout
+
+```
+include/, src/           core engine (src/storage = tree+pages+shard, src/tasks = request execution)
+ffi/                     C ABI (eloqstore_capi) over the C++ API
+rust/                    eloqstore-sys (raw FFI) + eloqstore (high-level SDK)
+python/                  Python SDK wrapping the C ABI
+tests/                   Catch2 unit/integration tests (one binary per .cpp)
+benchmark/, micro-bench/ throughput/latency drivers
+db_stress/               randomized stress + crash-recovery harness
+tools/                   page_checksum_tool, manifest_check_tool
+examples/                minimal C++ usage
+docs/architecture/       this documentation
+```
+
+Key entry points when reading code:
+
+- Public API: `include/eloq_store.h`, `include/kv_options.h`, `include/types.h`, `include/error.h`
+- Engine root: `src/eloq_store.cpp`
+- Per-shard runtime: `src/storage/shard.cpp`, `src/tasks/task.cpp`
+- Tree write path: `src/tasks/batch_write_task.cpp`, `src/tasks/write_task.cpp`
+- I/O backends: `include/async_io_manager.h`, `src/async_io_manager.cpp`
+- Durability: `src/storage/root_meta.cpp`, `src/storage/page_mapper.cpp`, `src/replayer.cpp`
+- GC: `src/file_gc.cpp`

--- a/docs/architecture/02-runtime-and-lifecycle.md
+++ b/docs/architecture/02-runtime-and-lifecycle.md
@@ -1,0 +1,129 @@
+# Runtime and Lifecycle
+
+Source: `include/eloq_store.h`, `src/eloq_store.cpp`, `include/kv_options.h`,
+`src/kv_options.cpp`, `include/storage/shard.h` (lifecycle parts).
+
+## Ownership graph
+
+`EloqStore` is the root owner of every long-lived runtime object:
+
+```
+EloqStore
+├── KvOptions options_            (validated + rewritten at Start)
+├── root_fds_                     (one O_DIRECTORY fd per store_path)
+├── CloudStorageService           (cloud mode only; HTTP worker threads)
+├── StandbyService                (standby modes only; rsync supervisor thread)
+├── Shard × num_threads
+│   ├── worker thread + WorkLoop
+│   ├── TaskManager               (pooled KvTask coroutines)
+│   ├── AsyncIoManager            (mode-specific subclass, owns io_uring)
+│   ├── PagesPool                 (aligned page buffers)
+│   ├── PageManager               (index-page cache + RootMetaMgr)
+│   └── GlobalRegisteredMemory*   (optional, zero-copy large values)
+├── ArchiveCrond                  (optional periodic archiver thread)
+├── PrewarmService                (optional cloud-cache warmup)
+└── EloqStoreModule               (ELOQ_MODULE_ENABLED embedding bridge)
+```
+
+A comment in `eloq_store.h` records one non-obvious ordering constraint:
+`cloud_service_` is declared before `shards_` because shard teardown triggers
+async HTTP cleanup that calls back into `CloudStorageService`.
+
+There is also a process-global `inline EloqStore *eloq_store` and a
+thread-local `inline thread_local Shard *shard` (`include/tasks/task.h`).
+Task code reaches its shard, options, and io manager through these — which is
+why **one process hosts at most one running EloqStore** and why task code must
+run on a shard thread.
+
+## Status state machine
+
+`EloqStore::Status`: `Stopped → Starting → Running → Stopping → Stopped`.
+`Start()` CAS-transitions Stopped→Starting and rejects concurrent or repeated
+starts. `SendRequest` accepts work only while `Running`.
+
+## Start() sequence
+
+`EloqStore::Start(branch, term, partition_group_id)` —
+the order is load-bearing; later steps assume earlier ones:
+
+1. `ValidateOptions(options_)` — sanity checks plus *rewrites* (e.g. in cloud
+   mode `max_write_concurrency == 0` is rewritten to `max_cloud_concurrency`;
+   store-path weight suffixes `path:w1,w2` are parsed out).
+2. Derive `StoreMode`; construct `CloudStorageService` or `StandbyService`
+   (and destroy whichever no longer applies).
+3. `InitStoreSpace()` — create/open every `store_path` root directory, hold
+   `root_fds_`, build `store_path_lut` (partition→path placement honoring disk
+   capacity or explicit weights).
+4. Record identity: `term_` (forced 0 in Local mode), `branch_`,
+   `partition_group_id_` (cloud only).
+5. Compute per-shard fd budget: `fd_limit` clamped to process
+   `RLIMIT_NOFILE` headroom minus `num_reserved_fd` (100), divided by
+   `num_threads`. Fails with `OpenFileLimit` if insufficient.
+6. Construct + `Init()` every `Shard` (allocates queues; the heavy I/O
+   bootstrap happens later on the shard's own thread).
+7. Start remote service: `CloudStorageService::Start()` then **block** on its
+   bootstrap (verifies bucket, CAS-upserts the `CURRENT_TERM_<branch>_<pg_id>`
+   object; a stale term fails the whole `Start`). Or `StandbyService::Start()`.
+8. `Shard::Start()` for each shard — spawns worker threads (normal build) or
+   marks shards runnable (module build).
+9. Module build only: register `EloqStoreModule` and notify workers.
+10. Start `ArchiveCrond` if `data_append_mode && num_retained_archives > 0 &&
+    archive_interval_secs > 0`.
+11. Start `PrewarmService` if `prewarm_cloud_cache` and mode is Cloud.
+12. Publish `Status::Running`.
+
+Any failure routes through `fail_start` → `CleanupRuntime(started_shards)`, so
+partial startups unwind in the same order as full shutdown.
+
+## Stop() / CleanupRuntime sequence
+
+Inverse dependency order — the goal is that no late completion touches freed
+state:
+
+1. `NotifyStoreStopping()` on every shard's io manager (stops ingest of new
+   background work, lets `WorkLoop` observe shutdown).
+2. Stop `PrewarmService`, then `ArchiveCrond` (background request *sources*
+   stop before request *executors*).
+3. Module build: flag shards `Stopping`, wait until each reports `Stopped`,
+   unregister the module.
+4. `Shard::Stop()` for each shard — joins the worker thread; the thread's exit
+   path runs `TaskManager::Shutdown()` then `PageManager::Shutdown()` then
+   `io_mgr_->Stop()` *on the shard thread* (these structures assume
+   shard-thread affinity even during teardown).
+5. Close `root_fds_`.
+6. Stop `StandbyService` / `CloudStorageService` — after shards, so in-flight
+   shard tasks waiting on remote completions can finish first.
+
+## KvOptions
+
+`include/kv_options.h` documents every field; highlights that shape behavior:
+
+- **Persisted-after-first-use options** (the struct marks them explicitly):
+  `store_path`, `cloud_store_path`, `data_page_size`, `pages_per_file_shift`,
+  `overflow_pointers`, `data_append_mode`, `enable_compression`, etc. Changing
+  them on an existing store is invalid.
+- **Topology**: `num_threads` (shards), `fd_limit`, `io_queue_size`,
+  `buffer_pool_size` (index-page cache per shard; data pages share it only if
+  `enable_data_page_cache`), `root_meta_cache_size` (global RootMeta LRU).
+- **Write shaping**: `max_write_batch_pages`, `max_write_concurrency`,
+  `write_buffer_size`/`write_buffer_ratio` (append-mode aggregation),
+  `manifest_limit` (snapshot-rotation threshold).
+- **Cloud**: `cloud_provider/endpoint/region/keys`, `local_space_limit` +
+  `reserve_space_ratio` (cache budget), `max_cloud_concurrency`,
+  `cloud_request_threads`, `allow_reuse_local_caches`, `prewarm_cloud_cache`.
+- **Compaction/GC**: `file_amplify_factor`, `segment_file_amplify_factor`,
+  `num_retained_archives`, `archive_interval_secs`.
+- **Zero-copy / large values** (doc 09): `segment_size`,
+  `global_registered_memories` XOR `pinned_memory_chunks`,
+  `gc_global_mem_size_per_shard`, `pinned_tail_scratch_slots`,
+  `segments_per_file_shift`.
+- `partition_filter` — predicate telling this instance which partitions it
+  owns (drives prewarm/global-op scoping in multi-instance deployments).
+- `LoadFromIni(path)` parses the same fields from an `.ini` file (used by
+  benchmarks/tools; see `benchmark/*.ini`).
+
+## Metrics
+
+With `ELOQSTORE_WITH_TXSERVICE` defined, per-shard `metrics::Meter` objects
+record request latency/counters and round durations (`InitializeMetrics`).
+Without it, only the data-page-cache hit/miss counters on `EloqStore` exist.

--- a/docs/architecture/03-request-api.md
+++ b/docs/architecture/03-request-api.md
@@ -1,0 +1,93 @@
+# Request API
+
+Source: `include/eloq_store.h`, `src/eloq_store.cpp` (request handling +
+fanout), `src/storage/shard.cpp` (`ProcessReq`), `include/error.h`.
+
+## Submission and completion contract
+
+Callers allocate a `KvRequest` subclass, fill its inputs, and submit:
+
+- `ExecSync(req)` — blocks via `req->Wait()`. Only legal when no callback is
+  set (`Wait()` CHECKs `callback_ == nullptr`). If the store is not `Running`,
+  the request completes immediately with `KvError::NotRunning`.
+- `ExecAsyn(req)` / `ExecAsyn(req, user_data, callback)` — returns `false` if
+  the store rejected the request (not running); otherwise the callback fires
+  exactly once on completion.
+
+`KvRequest::SetDone(err)` is the **single completion gate**: it either invokes
+the async callback or wakes the sync waiter — never both. Completion happens
+on the owning shard's thread (or on the store thread for immediate
+rejections), so callbacks must be cheap and must not block.
+
+Input lifetime: `ReadRequest`, `FloorRequest`, `ScanRequest`,
+`TruncateRequest` accept either borrowed `string_view`s or owned `std::string`
+storage. Borrowed inputs must stay alive until the request completes.
+
+The request object itself is caller-owned and must outlive completion; the
+engine never frees a `KvRequest`.
+
+## Request taxonomy
+
+`RequestType` ordering is semantic: `KvRequest::ReadOnly()` is implemented as
+`Type() < RequestType::BatchWrite`. **Inserting or reordering enum values
+changes read/write classification** — keep all read-only types before
+`BatchWrite`.
+
+| Category | Requests | Notes |
+|----------|----------|-------|
+| Point/range reads | `ReadRequest`, `FloorRequest`, `ScanRequest` | `ReadRequest.large_value_dest_` variant selects metadata-only / zero-copy IoStringBuffer / pinned-memory destination (doc 09). `ScanRequest` is iterative: `HasRemaining()` ⇒ resubmit with begin = previous end; pagination via `SetPagination`; prefetch clamped to `max_read_pages_batch`. Scans reject very-large values with `LargeValueUnsupported`. |
+| Remote listing | `ListObjectRequest`, `ListStandbyPartitionRequest` | Synchronous helpers bridging to cloud/standby services; `ListObjectRequest` paginates via continuation tokens. |
+| Partition-scoped writes (`WriteRequest` subclasses) | `BatchWriteRequest`, `ReopenRequest`, `TruncateRequest`, `DropRequest`, `ArchiveRequest`, `CompactRequest`, `LocalGcRequest`, `CleanExpiredRequest`, `CreateBranchRequest`, `DeleteBranchRequest` | Serialized per partition through the shard's pending-write queue (doc 04). `WriteRequest::next_` is an intrusive link used both by that queue and by callers managing free lists. |
+| Store-level fanout | `DropTableRequest`, `GlobalArchiveRequest`, `GlobalReopenRequest`, `GlobalListArchiveTagsRequest`, `GlobalCreateBranchRequest` | Handled in `EloqStore::SendRequest` *before* shard dispatch: they discover the affected partitions, materialize per-partition subrequests, fan them out (throttled by `max_global_request_batch` / `max_archive_tasks`), keep the first error, and complete when all subrequests do. |
+
+Semantics worth knowing:
+
+- **`BatchWriteRequest`** — atomic multi-key upsert/delete batch
+  (`WriteDataEntry{key, val, large_val_, timestamp, op, expire_ts}`) against
+  one partition. An entry whose timestamp is older than the stored version is
+  silently skipped.
+- **`ReopenRequest`** — discard the in-memory state of a partition and replay
+  its manifest; in cloud/standby mode this is how a node adopts a newer
+  remote snapshot. `SetTag()` reopens from an archive instead of the live
+  manifest. `SetClean(true)` tolerates a missing remote snapshot by
+  installing an empty one.
+- **`TruncateRequest`** — delete all keys ≥ position (used for log-style
+  tables).
+- **`ArchiveRequest` / `GlobalArchiveRequest`** — create (or delete, via
+  `Action`) a tagged manifest archive; `GlobalArchiveRequest::ResultArchive()`
+  returns the generated archive name.
+- **`GlobalCreateBranchRequest`** — forks every owned partition onto a new
+  branch; the engine salts the user-supplied name (`SetSaltTimestamp` makes
+  the salt deterministic) and returns it via `ResultBranch()`.
+
+## Routing
+
+`EloqStore::SendRequest`:
+
+1. Reject unless `Running`.
+2. Global fanout types are handled at store level (above).
+3. Everything else: `shards_[req->TableId().ShardIndex(shards_.size())]
+   ->AddKvRequest(req)` — a lock-free MPSC enqueue onto the shard's request
+   queue. The shard converts requests to tasks in `Shard::ProcessReq` (doc 04).
+
+## Error model and automatic retries
+
+`KvError` (`include/error.h`) is a flat enum; `ErrorString()` and
+`IsRetryableErr()` (OpenFileLimit/Busy/TryAgain) are defined alongside.
+
+Two retry loops live *inside* the engine (`Shard::StartTask` epilogue +
+`OnTaskFinished`):
+
+- **Auto-reopen retry** — if a task fails with `KvError::ResourceMissing` in
+  Cloud/StandbyReplica mode and the request type opts in
+  (`AutoReopenRetry()`: Read/Floor/Scan), the shard enqueues an internal
+  `ReopenRequest` for the partition and re-runs the original request after the
+  reopen completes, up to `auto_reopen_retry_times`. This is how readers
+  transparently follow a primary that has advanced the partition's term.
+  Only then is `SetDone` deferred; otherwise the error surfaces directly.
+- **OOM retry** — a task aborted by `KvError::OutOfMem` (e.g. buffer pool
+  exhaustion from pinned pages) is re-enqueued at the back of the shard queue
+  up to `auto_oom_retry_times`, giving other tasks a chance to release pins.
+
+`ExpiredTerm` is terminal by design: it means another process owns a newer
+term and this writer must stop (doc 06).

--- a/docs/architecture/04-execution-model.md
+++ b/docs/architecture/04-execution-model.md
@@ -1,0 +1,104 @@
+# Execution Model
+
+Source: `include/storage/shard.h`, `src/storage/shard.cpp`,
+`include/tasks/task.h`, `src/tasks/task.cpp`, `include/tasks/task_manager.h`,
+`src/tasks/task_manager.cpp`.
+
+## The one rule
+
+**Shard-thread affinity replaces locking.** Each shard owns one worker thread;
+all task state, page caches, FD tables, mappings, and pools belonging to that
+shard are mutated only from that thread. Asynchronous completions produced on
+other threads (cloud HTTP workers, standby supervisor) are *marshalled back*
+to the shard (via concurrent queues drained in the shard loop) and only there
+resume tasks. Any new async backend must follow this pattern; resuming a
+coroutine from a foreign thread is a correctness bug even if it appears to
+work.
+
+The thread-local `shard` pointer (`include/tasks/task.h`) plus helpers
+`ThdTask()`, `IoMgr()`, `Options()`, `Comp()` are how deep call stacks reach
+shard context without parameter plumbing.
+
+## Shard work loop
+
+`Shard::WorkLoop()` (normal build) repeats:
+
+1. `io_mgr_->Submit()` — flush prepared io_uring SQEs.
+2. `io_mgr_->PollComplete()` — reap CQEs; each completion either finishes a
+   blocked task's I/O (`FinishIo`) or processes a background write request.
+   Cloud/standby ready-queues are drained here too.
+3. `ExecuteReadyTasks()` — resume coroutines from `ready_tasks_`, then (when
+   the normal queue is empty) `low_priority_ready_tasks_` (background
+   compaction/GC yield here to protect foreground latency).
+4. Dequeue up to 128 new `KvRequest`s from the MPSC `requests_` queue
+   (blocking with 100 ms timeout only when fully idle) and feed each to
+   `OnReceivedReq`.
+
+Exit: when the store is stopping and the shard is idle. Teardown runs on the
+shard thread: `TaskManager::Shutdown()` → `PageManager::Shutdown()` →
+`io_mgr_->Stop()` (tasks may hold page pins, so task state dies first).
+
+In the module build (`ELOQ_MODULE_ENABLED`, doc 10) the same logic is exposed
+as `WorkOneRound()` and an external runtime drives it; `IsIdle()` tells the
+runtime whether the shard needs another round.
+
+## Tasks are pooled coroutines
+
+`KvTask` (`include/tasks/task.h`) wraps a `boost::context::continuation` with
+status (`Idle/Ongoing/Blocked/BlockedIO/Finished`), inflight-I/O counters, and
+an intrusive `next_` pointer. Stack size is `KvOptions::coroutine_stack_size`
+(32 KiB default; protected stacks in debug builds catch overflows).
+
+Scheduling primitives:
+
+- `Yield()` / `YieldToLowPQ()` — park the coroutine and re-enqueue it on the
+  (low-priority) ready queue; used to cooperate inside long loops.
+- `WaitIo()` / `FinishIo()` — park until `inflight_io_` completions arrive;
+  the completion path enqueues the task back on the ready queue.
+- `WaitIoResult()` — `WaitIo` + return the single completion's result code.
+- `WaitingZone` / `WaitingSeat` / `Mutex` — intra-shard wait lists (no real
+  locks; they park/wake coroutines). Used for FD open/close exclusion, pool
+  exhaustion waits, upload completion, etc.
+
+`TaskManager` keeps one free-list pool per task type (`BatchWriteTask`,
+`BackgroundWrite`, `ReadTask`, `ScanTask`, `ListObjectTask`,
+`ListStandbyPartitionTask`, `ReopenTask`). Pools grow on demand except the
+write pools, which are bounded — `GetBatchWriteTask` returning `nullptr` is
+the write-concurrency backpressure mechanism (`max_write_concurrency`).
+`NumActive()` feeds the idle check; `AddExternalTask/FinishExternalTask`
+account for background tasks (file cleaner, prewarmers) that live outside the
+pools.
+
+## Request → task dispatch
+
+`Shard::OnReceivedReq(req)`:
+
+- **Read-only requests** start immediately: `ProcessReq` grabs a pooled task
+  and `StartTask` runs the coroutine body (first slice runs inline until it
+  blocks on I/O).
+- **Write requests** (`!ReadOnly()`) are appended to the partition's
+  `PendingWriteQueue` and started by `TryStartPendingWrite` only if that
+  partition has no running write. **At most one write task runs per partition
+  at any time** — this is the engine's write-serialization point, sitting
+  above the coroutine layer. If the task pool is exhausted, the request stays
+  queued and `TryDispatchPendingWrites` retries when any write finishes.
+
+Each `PendingWriteQueue` also embeds singleton internal requests
+(`compact_req_`, `local_gc_req_`, `expire_req_`): background maintenance for a
+partition is queued exactly like a user write and therefore serializes with
+user writes (see `AddPendingCompact` / `AddPendingTTL` / `AddPendingLocalGc`).
+
+`StartTask`'s epilogue (in `include/storage/shard.h`) centralizes task
+completion: abort handling, OOM retry, auto-reopen retry, `SetDone`, and
+metrics. `OnTaskFinished` releases the partition's write slot, frees the task
+to its pool, and re-dispatches pending writes.
+
+## Blocking I/O from a task's perspective
+
+A task never calls a syscall directly. It calls `AsyncIoManager` methods
+(`ReadPage`, `WritePage`, `AppendManifest`, …) which prepare SQEs tagged with
+the task pointer, increment `inflight_io_`, and `WaitIo()`. The shard loop
+submits, polls, and resumes the task with results in `io_res_`/`io_flags_`.
+Cloud and standby operations look identical to the task: submit job → 
+`WaitIo()` → resumed by the shard after the remote thread pushes a completion
+onto the shard's ready queue.

--- a/docs/architecture/05-btree-and-page-formats.md
+++ b/docs/architecture/05-btree-and-page-formats.md
@@ -1,0 +1,123 @@
+# B+-Tree and Page Formats
+
+Source: `include/storage/page.h`, `include/storage/data_page.h`,
+`include/storage/mem_cached_page.h`, `include/storage/page_manager.h`,
+`include/storage/data_page_builder.h`, `include/storage/index_page_builder.h`,
+and the matching `src/storage/*.cpp`.
+
+## Tree shape
+
+Each partition is a B+-tree of 4 KiB pages (`data_page_size`):
+
+- **Index (non-leaf) pages** hold `key → child PageId` entries. *All* index
+  pages are resident in memory while the partition is open — this is the
+  design bet that buys one-I/O point reads.
+- **Data (leaf) pages** hold sorted KV entries and form a doubly-linked list
+  (`prev/next` PageIds in the header) for scans.
+- **Overflow pages** store values too big for a leaf but below the
+  very-large-value threshold; a leaf entry stores an encoded pointer array.
+- A second, smaller tree per partition — the **TTL tree** (root
+  `ttl_root_id_`) — indexes `expire_ts → key` so expiration scans don't touch
+  the main tree (doc 08).
+
+Every page begins with `checksum(8B) | page_type(1B)` (`include/storage/page.h`;
+xxhash, verified on load unless `skip_verify_checksum`).
+
+## On-disk encodings
+
+Two builder classes define the canonical formats; readers
+(`DataPageIter`, `IndexPageIter`, `PageRegionIter`) decode the same layout.
+**Any format change must update builder and iterator(s) together, and remain
+replayable by old data** unless a migration is designed.
+
+`DataPage` layout (`include/storage/data_page.h`):
+
+```
+checksum(8B) | type(1B) | content_len(2B) | prev_page(4B) | next_page(4B)
+| data blob | restart_array(N*2B) | restart_num(2B) | padding |
+```
+
+- Keys are prefix-compressed against their predecessor; every
+  `data_page_restart_interval` entries a *restart point* stores the full key.
+  The restart array enables binary search over regions.
+- Each entry stores `timestamp` and optional `expire_ts`.
+- The low bits of the value-length field encode value flavor
+  (`ValLenBit`): Overflow, Expire-present, and two compression bits.
+  Compression bits `0b11` means **very large value**: the value bytes are an
+  encoded segment-pointer array, not inline data (doc 09).
+- Values may be dictionary-compressed (zstd, per-partition dictionary stored
+  in the manifest) or standalone-compressed (`include/compression.h`).
+
+`OverflowPage` layout: `checksum | type | value_len(2B) | value … pointers(N*4B)
+| num_pointers(1B)` at page end. A big value is chained: the leaf entry holds
+the first `overflow_pointers` page ids; each overflow page can point onward.
+
+Index pages on disk are built by `IndexPageBuilder` with the same
+prefix-compression + restart scheme, entries being `key → PageId`.
+
+## In-memory index pages are *not* the disk bytes
+
+`MemCachedPage` (`include/storage/mem_cached_page.h`) is the cached form of an
+index page (and of data pages when `enable_data_page_cache` is on). It carries
+lifecycle state the disk format doesn't have:
+
+- `page_id_` / `file_page_id_` — durable identity.
+- `ref_cnt_` pin count (`Handle` is the RAII pin). Pinned pages can't be
+  evicted; tasks pin every page on their root-to-leaf path.
+- LRU links (`prev_/next_`) for `PageManager`'s active list.
+- A `WaitingZone` so concurrent readers of a page being loaded wait for the
+  single in-flight read instead of issuing duplicates.
+
+**Swizzling**: inside a `MappingSnapshot`, an index page's child references
+can be raw `MemCachedPage*` pointers instead of logical page ids (doc 06).
+`PageManager::FindPage` returns the swizzled child directly on the hot path;
+`MappingSnapshot::Unswizzling` writes the durable id back before a page can be
+recycled.
+
+## PageManager: the per-shard cache
+
+`PageManager` (one per shard) owns:
+
+- The cached-page pool (`buffer_pool_size` bytes), LRU eviction via the
+  active list; only unpinned pages are evictable. When eviction can't find a
+  victim, allocation fails up the stack as `KvError::OutOfMem` → the request
+  is retried (doc 03).
+- `RootMetaMgr` — the LRU of per-partition `RootMeta` (doc 06).
+- `SeekIndex(mapping, root, key)` — the root-to-leaf descent used by all
+  readers; returns the data-page id that may contain the key.
+- Mapping arenas (`MappingArena`, `MappingChunkArena`) recycling the chunked
+  storage behind mapping tables.
+
+Data-page caching is optional (`enable_data_page_cache`): when on, leaf pages
+share the same pool/LRU and `LoadDataPage` consults the cache (hits are
+read-only views; `LoadDataPageForUpdate` copies out a private buffer). Hit and
+miss counters surface through `EloqStore::DataCacheHits/Misses`.
+
+`PagesPool` (`include/storage/page.h`) is the underlying aligned-buffer
+allocator. Buffers may be io_uring-*registered* (fixed buffers); `Page`
+steals the pointer's top bit to remember registration so I/O paths can choose
+fixed vs normal opcodes.
+
+## Copy-on-write writes
+
+Writers never mutate a published page. `BatchWriteTask::Apply`
+(`src/tasks/batch_write_task.cpp`) merges a sorted batch into the tree by:
+
+1. `MakeCowRoot` — clone the current root metadata + mappers into a private
+   `CowRootMeta` (doc 06).
+2. Descend with an explicit index stack (`write_tree_stack.h`), load each
+   affected leaf, merge entries via `DataPageBuilder`, splitting or merging
+   leaves as needed (`leaf_triple_` keeps the three adjacent leaves so the
+   doubly-linked leaf list stays consistent; `Redistribute` rebalances).
+3. Allocate new logical/physical pages through the CoW mapper
+   (`AllocatePage`), write new pages, free replaced ones into the snapshot's
+   `to_free_file_pages_`.
+4. Rebuild the affected index path bottom-up (`FinishIndexPage` /
+   `FlushIndexPage`).
+5. `UpdateMeta` → flush a manifest record, publish the new root
+   (`PageManager::UpdateRoot`), signal compaction if amplification crossed the
+   threshold.
+
+Readers that started before step 5 keep their `MappingSnapshot::Ref` and old
+root; freed file pages are only recycled when the last reference to the old
+snapshot dies (doc 06). This is the lock-free read-during-write story.

--- a/docs/architecture/06-persistence-and-recovery.md
+++ b/docs/architecture/06-persistence-and-recovery.md
@@ -1,0 +1,137 @@
+# Persistence, Recovery, Terms and Branches
+
+Source: `include/storage/root_meta.h`, `src/storage/root_meta.cpp`,
+`include/storage/page_mapper.h`, `src/storage/page_mapper.cpp`,
+`include/replayer.h`, `src/replayer.cpp`, `include/manifest_buffer.h`,
+`include/common.h` (file naming), `include/types.h` (branch types).
+
+## The durability anchor
+
+A page write is durable only when a manifest record describing its mapping has
+been persisted. Everything hangs off three structures:
+
+- **`RootMeta`** — per-partition durable state bundle: main root `root_id_`,
+  TTL root `ttl_root_id_`, the data `mapper_` and segment `segment_mapper_`,
+  live mapping/segment snapshots, manifest size, next TTL expiration,
+  compression dictionary, and `first_unflushed_*_fp_id_` watermarks consumed
+  by GC. Cached globally in `RootMetaMgr` (LRU, `root_meta_cache_size`),
+  pinned via `Handle` while any task uses it.
+- **`PageMapper` / `MappingSnapshot`** — the logical→physical indirection.
+  `MappingTbl` is a chunked array `PageId → uint64`, where each value is
+  type-tagged (`ValType`): a `FilePageId`, a swizzled `MemCachedPage*`, a
+  free-list `PageId` link, or Invalid. Snapshots are immutable-by-version:
+  a CoW write produces a *new* snapshot that records pending changes; readers
+  hold `MappingSnapshot::Ref`s. Each snapshot lists `to_free_file_pages_` and
+  links to `next_snapshot_` — physical pages are recycled only after every
+  older snapshot is released (no reader can see a reused page).
+- **`FilePageAllocator`** — turns logical growth into physical placement.
+  `AppendAllocator` (append mode; monotonically increasing FilePageIds,
+  tracks `min_file_id_`/`empty_file_cnt_` for space accounting) or
+  `PooledFilePages` (in-place mode; free-id pool). The allocator is
+  *reconstructed from manifest state* on replay, never persisted separately.
+
+## Manifest format
+
+Built by `ManifestBuilder` (`include/storage/root_meta.h` documents the exact
+byte layout). A manifest file = one **snapshot** record + N appended **log**
+records, every record framed as:
+
+```
+checksum(8B) | root(4B) | ttl_root(4B) | payload_len(4B) | payload
+```
+
+- Snapshot payload: `max_fp_id`, compression dictionary, full data mapping
+  table, `BranchManifestMetadata` (branch name, term, per-branch file ranges),
+  segment `max_fp_id` + full segment mapping.
+- Log payload: data-mapping deltas, `BranchManifestMetadata`, segment-mapping
+  deltas.
+
+Each committing write (`WriteTask::FlushManifest`) appends one log record;
+when the file exceeds `manifest_limit`, the writer instead writes a fresh
+snapshot to a temp file and atomically renames it (`SwitchManifest`). In
+cloud mode each append also uploads the manifest object (doc 07).
+
+## Replay
+
+`Replayer::Replay(ManifestFile*)` parses the snapshot, then applies log
+records in order, rebuilding mapping tables, roots, branch metadata, and file
+watermarks. A corrupt or torn record stops replay at the last valid boundary
+(`corrupted_log_found_`, `file_size_before_corrupted_log_`) — torn tails from
+crashes are expected and safely truncated. `GetMapper`/`GetSegmentMapper`
+materialize fresh `PageMapper`s with correctly seeded allocators.
+
+Replay is the *single* restore path, used by:
+
+- Cold open of a partition (first access after start).
+- `ReopenRequest` — drop in-memory state, re-replay (possibly a newer manifest
+  fetched from cloud/standby, possibly an archive tag).
+- `PageManager::InstallExternalSnapshot` — install a remote snapshot into the
+  RootMeta chain without local CoW writes; missing remote manifest can fall
+  back to `InstallEmptySnapshot` (Reopen-clean).
+
+Changing manifest encoding therefore changes cold start, crash recovery,
+cloud adoption, and archive restore at once — design migrations accordingly.
+
+## On-disk layout and file naming
+
+Per partition directory `<store_path>/<tbl>.<partition>/` (placement across
+multiple `store_path`s via `store_path_lut`):
+
+| File | Name format (all in `include/common.h`) |
+|------|------------------------------------------|
+| Data file | `data_<file_id>_<branch>_<term>` (legacy `data_<id>_<term>`) |
+| Segment file | `segment_<file_id>_<branch>_<term>` |
+| Manifest | `manifest_<branch>_<term>` (legacy `manifest_<term>`) |
+| Archive | `manifest_<branch>_<term>_<tag>` |
+| Temp | `*.tmp` suffix during atomic write+rename |
+
+Store-root level (cloud bucket root in cloud mode):
+`CURRENT_TERM_<branch>_<pg_id>` — content is the current term number.
+
+Data/segment files are sized by `pages_per_file_shift` /
+`segments_per_file_shift`. `TypedFileId` (`include/types.h`) encodes
+data-vs-segment in the LSB (`file_id << 1 | is_segment`) so both kinds share
+one FD table and one branch-range lookup; sentinels near `MaxFileId` denote
+the manifest and directory FDs.
+
+## Terms
+
+The embedding system passes a `term` to `Start()` (0 in Local mode). Files and
+manifests are stamped with the writer's term. In cloud mode,
+`CloudStorageService` bootstrap CAS-updates `CURRENT_TERM_<branch>_<pg_id>`
+(ETag-guarded); a writer that discovers a newer published term gets
+`KvError::ExpiredTerm` and must stop — this fences zombie writers after
+failover. Readers/GC treat *newer-term* files conservatively (see BranchGuard
+below). `ManifestTermFromFilename` etc. parse terms back out of names.
+
+## Branches
+
+A branch is a fork of a partition sharing history with its parent:
+
+- `BranchManifestMetadata` in every manifest carries the branch's name, term,
+  and `BranchFileMapping` — a vector of `BranchFileRange{branch, term,
+  max_file_id, max_segment_file_id}` sorted by file id. Because file ids are
+  allocated monotonically, a binary search by file id resolves *which
+  (branch, term) owns any file* — that is how a child branch reads pages that
+  physically live in files written by an ancestor branch.
+- `CreateBranch` (per partition, via `BackgroundWrite::CreateBranch`) writes a
+  branch manifest for the new branch that inherits the parent's mapping and
+  file ranges — O(1), no data copy. `GlobalCreateBranchRequest` fans this out
+  and salts the branch name (`<name>-<salt>`), returning `ResultBranch()`.
+- `EloqStore::Start(branch, …)` opens the store *on* a branch; the active
+  branch flows to each `IouringMgr` (`SetActiveBranch`) and stamps new files.
+- `DeleteBranch` removes a branch's manifest and its uniquely-owned files
+  (`DeleteBranchFiles`); shared ancestor files are protected by the
+  file-range bookkeeping and GC rules.
+- `RetainedFileKey{file_id, branch, term}` exists because sibling branches
+  forked at the same point can allocate overlapping file ids — file identity
+  for GC is the triple, not the id (doc 08).
+
+## Archives
+
+`ArchiveRequest`/`BackgroundWrite::CreateArchive` snapshots the current
+manifest into `manifest_<branch>_<term>_<tag>` (append mode only). Archives
+pin every file they reference (GC reads archive manifests — doc 08) and are
+pruned to `num_retained_archives`. `ReopenRequest::SetTag` /
+`CloudStoreMgr::RefreshManifest(tag)` restore from an archive;
+`GlobalListArchiveTagsRequest` enumerates them.

--- a/docs/architecture/07-io-stack.md
+++ b/docs/architecture/07-io-stack.md
@@ -1,0 +1,135 @@
+# I/O Stack
+
+Source: `include/async_io_manager.h`, `src/async_io_manager.cpp`,
+`include/storage/object_store.h`, `src/storage/object_store.cpp`,
+`include/storage/cloud_backend.h`, `src/storage/cloud_backend.cpp`,
+`include/cloud_storage_service.h`, `src/cloud_storage_service.cpp`,
+`include/standby_service.h`, `src/standby_service.cpp`,
+`include/direct_io_buffer.h`.
+
+## Layering, not alternatives
+
+`AsyncIoManager` is the shard-facing storage interface. One instance per
+shard, chosen by `AsyncIoManager::Instance` from the store mode:
+
+```
+AsyncIoManager (abstract: ReadPage/WritePage/ReadSegments/Manifest ops/...)
+├── MemStoreMgr        store_path empty — pages and manifests in RAM (tests)
+└── IouringMgr         local filesystem over io_uring — the substrate
+    ├── CloudStoreMgr  + object storage sync; local files become a cache
+    └── StandbyStoreMgr + rsync pull-through from a master
+```
+
+The two remote managers *extend* the local one: local manifest and page
+semantics stay identical, which is what keeps recovery (doc 06) uniform
+across modes. New backends should subclass within this contract and must
+route completions back through the owning shard (doc 04).
+
+## IouringMgr (local substrate)
+
+Owns the shard's `io_uring` (`io_queue_size` entries, DEFER_TASKRUN; a forced
+`io_uring_enter` every 10 empty polls works around a CQE-delivery window that
+otherwise deadlocks at high read concurrency — see the comment at
+`kForceSubmitEveryNoOps`).
+
+Responsibilities:
+
+- **Page I/O** — `ReadPage`/`ReadPages` (batched, into pool buffers, fixed
+  reads when the buffer is registered), `WritePage`. `ConvFilePageId` splits a
+  `FilePageId` into `(file_id, offset)` by `pages_per_file_shift`.
+- **FD cache** — `LruFD` per (partition, `TypedFileId`), doubly-linked LRU
+  bounded by the shard's fd budget; `EvictFD` closes idle descriptors.
+  Open/close exclusion per FD via a coroutine `Mutex`. Data files open with
+  `O_DIRECT`. Directory FDs and the manifest FD are cached under sentinel
+  TypedFileIds. `LruFD::Ref` is the RAII reference; eviction skips referenced
+  FDs.
+- **Manifest ops** — `AppendManifest`, `SwitchManifest` (write temp +
+  rename), `GetManifest` (buffered reader), archive/branch-manifest
+  create/delete, `DropManifest`.
+- **Append-mode merged writes** — small page writes destined for the same
+  file tail are aggregated in `write_buf_` slots (`WriteBufferAggregator`,
+  `SubmitMergedWrite`) into ~`write_buffer_size` chunks, cutting SQE and
+  device-write counts.
+- **Branch bookkeeping** — the authoritative in-memory
+  `branch_file_mapping_` per partition (Get/SetBranchFileIdTerm,
+  SetBranchFileMapping) with interned branch-name storage.
+- **Registered buffers** — page-pool registration (fixed I/O), plus the
+  zero-copy bootstrap (`BootstrapRing` with `GlobalMemoryConfig`): registers
+  caller `GlobalRegisteredMemory` chunks or KV-cache pinned chunks, the
+  private GC pool, and the pinned-write tail-scratch pool (doc 09).
+- `ReadSegments`/`WriteSegments` — batched fixed I/O on segment files
+  (doc 09).
+
+## CloudStoreMgr (cloud overlay)
+
+Local disk = bounded LRU cache of cloud objects; object store = durable copy.
+
+- **Upload path**: as append-mode writes flush, `OnFileRangeWritePrepared`
+  captures the written ranges into the task's `UploadState`; sealing a file
+  (`OnDataFileSealed`) or committing (manifest append) uploads the
+  file/manifest via `ObjectStore` upload tasks. A write request completes
+  only after its uploads are acknowledged (`WaitPendingUploads`), so a
+  completed write is durable in the object store, not merely on local disk.
+  Cloud mode skips `fdatasync` entirely (local files are re-downloadable).
+- **Download path**: a read missing its local file (`OpenFile` local miss)
+  triggers `DownloadFile` into the cache and retries; `GetManifest` can fetch
+  the manifest object; `RefreshManifest(tag)` pulls a newer/archived manifest
+  before replay (used by reopen and auto-reopen, doc 03).
+- **Cache management**: every cached file is tracked (`closed_files_` LRU,
+  `used_local_space_` vs per-shard slice of `local_space_limit`).
+  `ReserveCacheSpace` evicts closed files (the background `FileCleaner` task)
+  before creating/downloading; "evicting path" keys serialize concurrent
+  open-vs-unlink on the same filename. Partition directory removal is
+  coordinated with directory-FD busy counts (`RegisterDirBusy` /
+  `pending_dir_cleanup_`).
+- **Warm restart**: with `allow_reuse_local_caches`,
+  `RestoreLocalCacheState()` walks partition dirs at Init, re-registers
+  reusable files into the LRU (removing `*.tmp` strays and empty dirs) so a
+  restart doesn't re-download the working set.
+- **Concurrency limits**: cloud ops take a slot (`AcquireCloudSlot`,
+  `max_cloud_concurrency`) and a pooled `DirectIoBuffer`
+  (`AcquireCloudBuffer`); both park the coroutine when exhausted.
+- **Terms**: `ReadTermFile`/bootstrap CAS on `CURRENT_TERM_*` (doc 06);
+  `process_term_`/`partition_group_id_` stamp uploads and validate manifests.
+
+## Cloud transport
+
+Three layers, crossing the thread boundary exactly once each way:
+
+1. **`ObjectStore`** (per shard) — task-facing API; wraps work items as
+   `ObjectStore::{Download,Upload,List,Delete}Task` tagged with the owning
+   `KvTask` and shard.
+2. **`CloudStorageService`** (per store) — `cloud_request_threads` worker
+   threads, each running a curl multi loop; jobs from a given shard always go
+   to the same worker (curl handles are not thread-safe). Also runs the
+   bootstrap term-file CAS at Start.
+3. **`AsyncHttpManager`** (per shard, driven by the service worker) — builds
+   signed HTTP requests via the pluggable `CloudBackend`
+   (`include/storage/cloud_backend.h`; AWS S3 / GCS variants selected by
+   `cloud_provider`), handles retry with backoff and error classification
+   (`Timeout` vs `CloudErr` vs `OssInsufficientStorage`…), parses list
+   responses.
+
+Completion: the worker thread never touches task state; it enqueues the
+finished `ObjectStore::Task` onto the owning shard's
+`cloud_ready_tasks_` queue (`EnqueueCloudReadyTask`); the shard loop drains it
+and resumes the waiting coroutine.
+
+## StandbyStoreMgr + StandbyService (standby overlay)
+
+`StandbyStoreMgr` fills local misses by *pulling from the master* instead of
+an object store. `StandbyService` runs a single supervisor thread that spawns
+bounded (`standby_max_concurrency`) rsync/ssh child processes (pidfd+epoll
+supervision), with job types: rsync a partition's files, prepare/stage a
+remote manifest (staged to temp + atomic rename before replay), list remote
+partitions. Per-partition in-flight dedup; completions flow back through
+per-shard ready queues (`ProcessReadyTasks`). Master address/store-paths are
+hot-updatable (`UpdateStandbyMasterAddr/StorePaths`). A master in
+`StandbyMaster` mode is just a local store whose directory layout replicas
+may rsync.
+
+## DirectIoBuffer
+
+`include/direct_io_buffer.h`: page-aligned, size-reserved buffers used for
+non-page I/O (uploads, downloads, manifest snapshots, GC file reads), pooled
+per shard (`direct_io_buffer_pool_size`, `non_page_io_batch_size` batching).

--- a/docs/architecture/08-data-lifecycle.md
+++ b/docs/architecture/08-data-lifecycle.md
@@ -1,0 +1,120 @@
+# Data Lifecycle: Reads, Writes, Compaction, GC
+
+Source: `src/tasks/read_task.cpp`, `src/tasks/scan_task.cpp`,
+`src/tasks/batch_write_task.cpp`, `src/tasks/write_task.cpp`,
+`src/tasks/background_write.cpp`, `src/tasks/reopen_task.cpp`,
+`src/tasks/archive_crond.cpp`, `src/tasks/prewarm_task.cpp`,
+`include/file_gc.h`, `src/file_gc.cpp`.
+
+## Point read (`ReadTask`)
+
+1. `PageManager::FindRoot(tbl_id)` — pins the partition's `RootMeta` (cold
+   partitions replay their manifest here, doc 06) and takes a
+   `MappingSnapshot::Ref`.
+2. `SeekIndex` descends the in-memory index (swizzled pointers; missing index
+   pages are loaded once, with concurrent waiters parking on the page).
+3. Load the one data page (through the optional data-page cache), binary
+   search via `DataPageIter`.
+4. Resolve the value: inline → copy out; overflow → `GetOverflowValue` chases
+   overflow pages; compressed → decompress; very large →
+   metadata-from-trailer and/or segment reads (doc 09).
+
+`Floor` is the same descent with floor semantics (`SeekFloor`).
+
+## Scan (`ScanTask` / `ScanIterator`)
+
+Builds an explicit index-frame stack to the begin key, then iterates leaves
+via their next-links, prefetching up to `prefetch_page_num` leaves per batch
+(`ReadPages`). Results accumulate into the request until the
+entry/byte pagination limit; `HasRemaining()` tells the caller to resubmit
+from the last key. Holding the mapping snapshot for the whole scan page keeps
+the view consistent; very large values abort with `LargeValueUnsupported`.
+
+## Batch write (`BatchWriteTask`)
+
+One write task per partition at a time (doc 04). `Apply()`:
+
+1. `MakeCowRoot` — private `CowRootMeta` with cloned mappers.
+2. Sort/dedup the batch; entries older (timestamp) than the stored version
+   are skipped. Deletes drop entries; TTL changes are mirrored into a
+   `ttl_batch_` applied to the TTL tree afterward.
+3. Merge into leaves page-by-page (`ApplyOnePage`), CoW-allocating
+   replacement pages, maintaining the leaf doubly-linked list via the
+   `leaf_triple_`, writing overflow pages / large-value segments as needed.
+4. Rebuild touched index path bottom-up.
+5. `UpdateMeta` → `FlushManifest` (append a manifest log record, or rotate to
+   a fresh snapshot past `manifest_limit`; in cloud mode wait for uploads) →
+   `PageManager::UpdateRoot` publishes the new root → old snapshot's freed
+   file pages recycle when its last reader releases.
+6. `UpdateMeta(trigger_compact=true)` checks both mappers' space
+   amplification and flags the shard's pending-compact set; `TriggerTTL` /
+   `TriggerFileGC` similarly self-schedule maintenance.
+
+Failure at any point: `Abort()` — the CoW state is discarded, `AbortWrite`
+cancels buffered file writes, the published tree is untouched.
+
+`Truncate`, `Drop`, `CleanExpiredKeys` are alternate entry points on the same
+task class (drop deletes the manifest first, making deletion durable, then
+relies on GC for files).
+
+## Background maintenance (`BackgroundWrite`)
+
+All run through the same per-partition write queue, so they serialize with
+user writes. Scheduled via shard pending-sets (`AddPendingCompact/TTL/LocalGc`)
+which enqueue the embedded singleton requests in each `PendingWriteQueue`.
+
+- **Compaction** (`Compact()`, append mode only): one `MakeCowRoot`; rewrite
+  pass over under-utilized data files (live pages re-written to the tail,
+  per-file utilization re-checked against `file_amplify_factor`), then over
+  segment files (`segment_file_amplify_factor`, yielding every
+  `segment_compact_yield_every` segments to the low-priority queue); one
+  `UpdateMeta(false)`; one `TriggerFileGC`.
+- **TTL cleanup** (`CleanExpiredKeys`): when `RootMeta::next_expire_ts_` has
+  passed, scan the TTL tree range `[0, now]`, delete expired keys from both
+  trees.
+- **Local GC / file GC** — below.
+- **CreateArchive / CreateBranch / DeleteBranch** — manifest-level operations
+  (doc 06) executed under the write lock for the partition.
+
+`ArchiveCrond` (its own thread) periodically submits archive requests for all
+owned partitions at `archive_interval_secs`, bounded by `max_archive_tasks`.
+
+## File garbage collection (`include/file_gc.h`, `src/file_gc.cpp`)
+
+Deletes data/segment files no longer referenced by any manifest, archive, or
+in-flight write. Two drivers, same rules:
+
+- `ExecuteLocalGC` (local/standby modes) — lists the partition directory.
+- `ExecuteCloudGC` (cloud mode) — lists the partition's objects; deletions
+  propagate to the local cache (`ScheduleLocalFileCleanup`, then directory
+  cleanup when the partition empties).
+
+Inputs assembled per run:
+
+1. **Retained sets** — walk the live mapping tables (`GetRetainedFiles`) and
+   every on-disk/cloud manifest *including archives*
+   (`AugmentRetainedFilesFromBranchManifests`) collecting
+   `RetainedFileKey{file_id, branch, term}` for data and segment files.
+2. **BranchGuards** — per-branch in-flight write protection:
+   `{newest_term, least_unflushed_file_id, least_unflushed_seg_file_id}`
+   derived from `RootMeta::first_unflushed_*_fp_id_` (active branch) and
+   manifest file ranges, maxed together. A file whose term ≥ the branch's
+   newest term and whose id ≥ the watermark may belong to a write that hasn't
+   flushed its manifest yet — never delete it. The `>=` (not `==`) term
+   comparison protects against a concurrent primary that bumped its term but
+   hasn't flushed a manifest. Callers pre-seed the guard for
+   (active branch, process term) so the very first un-manifested file is safe.
+3. Files not in the retained set and not guard-protected are deleted; old
+   archives beyond `num_retained_archives` are pruned (`DeleteOldArchives`).
+
+File identity is the (id, branch, term) triple — sibling branches can reuse
+ids (doc 06).
+
+## Prewarm (`src/tasks/prewarm_task.cpp`)
+
+Cloud mode + `prewarm_cloud_cache`: at startup `PrewarmService` lists the
+bucket (respecting `partition_filter`), feeds candidate files through each
+shard's bounded `prewarm_queue_`, and `prewarm_task_count` `Prewarmer` tasks
+per shard download them into the local cache until space or listing is
+exhausted; foreground load always preempts (prewarm runs only when the shard
+is otherwise idle — `NeedPrewarm`/`RunPrewarm` in the work loop).

--- a/docs/architecture/09-large-values-zero-copy.md
+++ b/docs/architecture/09-large-values-zero-copy.md
@@ -1,0 +1,110 @@
+# Very Large Values and Zero-Copy I/O
+
+Source: `include/global_registered_memory.h`, `src/global_registered_memory.cpp`,
+`include/io_buffer_ref.h`, `include/io_string_buffer.h`,
+`include/storage/data_page.h` (large-value encoding), `src/tasks/task.cpp`
+(`GetLargeValue*`), `src/tasks/batch_write_task.cpp` (`WriteLargeValue*`),
+`include/async_io_manager.h` (segments, pinned chunks, tail scratch).
+
+Historical design docs `docs/zero_copy_read.md` / `docs/zero_copy_metadata.md`
+motivated this feature; where they disagree with this doc, the code (and this
+doc) win.
+
+## Problem
+
+KV-cache workloads read/write 1–10 MiB values. Routing those through 4 KiB
+overflow pages and memcpy chains is wasteful. The design stores big values in
+**segment files** and moves bytes with io_uring *fixed* (pre-registered
+buffer) I/O end-to-end, so the engine never copies value bytes.
+
+## Storage: segments
+
+- A value larger than the overflow threshold is split into
+  K = ceil(len / `segment_size`) segments (default 256 KiB, 4 KiB-aligned).
+- Segments live in append-only **segment files**
+  (`segment_<id>_<branch>_<term>`, `segments_per_file_shift` segments per
+  file), allocated by a second `AppendAllocator` on
+  `RootMeta::segment_mapper_` — a full parallel mapping
+  (logical segment id → physical file segment), persisted in the manifest as
+  snapshot + deltas, replayed like the page mapping (doc 06).
+- The leaf entry's value field stores the encoding (compression bits `0b11`
+  marks it):
+
+```
+word0(4B: bit31 = has-metadata, bits30..0 = actual_length)
+| K × uint32 logical segment ids
+| [uint16 metadata_len | metadata bytes]        (optional trailer)
+```
+
+  K is derived from `actual_length`, not stored. The optional **metadata
+  trailer** (≤ 64 KiB) lets callers attach a small blob (e.g. KV-cache block
+  descriptors) readable *without* touching the segments —
+  metadata-only reads cost the same as a normal point read.
+- GC and compaction treat segment files like data files, with their own
+  amplification knob (`segment_file_amplify_factor`) and retained-set/guard
+  rules (doc 08). Scans don't support large values.
+
+## Memory: two mutually exclusive modes
+
+Configured in `KvOptions`; both register memory as io_uring fixed buffers at
+`BootstrapRing`:
+
+### 1. `global_registered_memories` (legacy zero-copy mode)
+
+One external `GlobalRegisteredMemory` per shard, owned by the embedding
+system and shared with its networking/cache layers (registered in multiple
+rings; per-ring `buf_index = chunk_idx + GlobalRegMemIndexBase()`).
+
+`GlobalRegisteredMemory` hands out fixed-size segments from a **lock-free
+ABA-tagged Treiber stack**: `head_` packs `(version32, seg_idx32)`; successor
+indices live in a separate `successors_` array — never inside the segment
+itself — both to avoid data races with in-flight DMA into popped segments and
+to keep segment cache lines cold (the header comment documents this in
+detail). `GetSegment(yield)` loops `TryGetSegment → evict_func_() → yield()`
+under pressure; `Recycle(ptr, chunk_idx)` returns one segment.
+
+Values travel as `IoStringBuffer` = vector of `IoBufferRef{data_, buf_index_}`
+fragments + logical size:
+
+- **Write**: caller builds an `IoStringBuffer` in `WriteDataEntry.large_val_`;
+  `BatchWriteTask::WriteLargeValue` maps fragments → `WriteSegments` fixed
+  writes.
+- **Read**: `ReadRequest.large_value_dest_ = IoStringBuffer{}`; the read task
+  allocates segments from the shard's pool (`GetLargeValue`), fixed-reads
+  into them, and the caller drains fragments and must `Recycle` them
+  (`EloqStore::GlobalRegMemIndexBase(shard_id)` provides the index base).
+
+### 2. `pinned_memory_chunks` (KV-cache pinned mode)
+
+The caller (e.g. a PyTorch-managed KV cache) owns big pinned chunks shared by
+all shards; each shard registers them in its ring. Values move directly
+between the caller's contiguous pinned buffer and segment files:
+
+- **Write**: `WriteDataEntry.large_val_ = {ptr, size}` (plus `val_` as the
+  metadata blob). The writer splits the range into K chunks,
+  resolves the fixed-buffer index once (`BufIndexForAddress` /
+  `PinnedChunkFor`), and issues `WriteSegments`.
+  **Tail handling**: the last segment's fixed write covers
+  `K*segment_size - size` bytes past the value end; if those bytes still lie
+  inside the registered chunk this is free, otherwise the writer copies the
+  tail into a per-shard registered **tail-scratch slot**
+  (`AcquireTailScratch`, `pinned_tail_scratch_slots` × `segment_size` pool,
+  zero-padded) and writes from there.
+- **Read**: `ReadRequest.large_value_dest_ = {ptr, size}` reads segments
+  straight into the caller's range (`GetLargeValueContiguous`; the range must
+  sit inside one registered chunk; partial tail reads are 4 KiB-aligned).
+  `large_value_only_ = true` skips metadata extraction for the
+  "metadata first, bytes later" pattern.
+- The `IoStringBuffer` read arm is **rejected** in pinned mode: fragments
+  would come from the internal GC pool the caller can't recycle.
+- Background GC/compaction can't use caller memory, so EloqStore allocates a
+  private per-shard `GlobalRegisteredMemory`
+  (`gc_global_mem_size_per_shard`, must hold `max_segments_batch` segments)
+  for its own segment rewrites.
+
+## Testing notes
+
+Fixed-buffer registration pins pages against `RLIMIT_MEMLOCK`. The
+`large_value_*` test binaries use a custom Catch2 main
+(`tests/large_value_main.cpp`) that raises the limit to 2 GiB; CI runs with
+`--ulimit memlock=-1:-1`.

--- a/docs/architecture/10-bindings-and-embedding.md
+++ b/docs/architecture/10-bindings-and-embedding.md
@@ -1,0 +1,70 @@
+# Bindings and Embedding
+
+Source: `ffi/include/eloqstore_capi.h`, `ffi/src/eloqstore_capi.cpp`,
+`rust/eloqstore-sys/`, `rust/eloqstore/`, `python/src/eloqstore/`,
+`include/eloqstore_module.h`, `src/eloqstore_module.cpp`.
+
+Dependency direction is strictly one-way: every layer adapts API *shape* but
+must preserve the native store's lifecycle, completion, and memory-ownership
+model. None of them invent a second data path.
+
+```
+C++  EloqStore / KvRequest            (the only engine API)
+└── ffi/ eloqstore_capi               C ABI, opaque handles
+    ├── rust/eloqstore-sys            raw extern "C" declarations + lib embedding
+    │   └── rust/eloqstore            safe high-level SDK
+    └── python/ (ctypes via _ffi.py)  Python SDK
+```
+
+## C ABI (`ffi/`)
+
+- Flat C functions over opaque handles: `CEloqStoreHandle`,
+  `CTableIdentHandle`, `CScanRequestHandle`, `CBatchWriteHandle`. Request
+  objects survive as handles only where state spans multiple calls (scans,
+  batch-write builders); simple ops are single functions.
+- `CEloqStoreStatus` mirrors `KvError` (keep in sync when adding errors).
+- Results backed by native allocations come with dedicated `*_free`
+  functions; handle types have their own destructors. Crossing the boundary
+  copies values — the zero-copy large-value paths are *not* exposed through
+  the C ABI today.
+- Built as the `eloqstore_capi` shared library (see root `CMakeLists.txt`),
+  installed alongside `eloq_store.h` headers.
+
+## Rust SDK (`rust/`)
+
+- `eloqstore-sys`: re-declares the C ABI, plus build logic that either links a
+  prebuilt library or embeds/builds the native one
+  (`ELOQSTORE_STATIC_EXE=1` for static examples; see `embedded_lib.rs` and
+  `rust/README.md`).
+- `eloqstore`: two API styles over the same core — RocksDB-style convenience
+  methods (`put/get/delete/scan`) and a typed request/response trait layer
+  (`request.rs`, `response.rs`, `traits.rs`). `Options`/`TableIdentifier`
+  wrap `KvOptions`/`TableIdent`. Integration tests:
+  `cargo test -p eloqstore --test integration_test -- --test-threads=1`.
+
+## Python SDK (`python/`)
+
+`eloqstore.Client(Options(...))` loads `libeloqstore_capi.so` via ctypes
+(`_ffi.py`; override path with `ELOQSTORE_PY_LIB`). The wheel build
+(`build_hooks.py`) compiles the native library. Design notes:
+`docs/design/python_sdk.md`.
+
+## EloqModule embedding (`ELOQ_MODULE_ENABLED`)
+
+A different integration axis: same process, *externally scheduled*. Built
+only when the embedding runtime (EloqKV's tx service, with bthread) defines
+`ELOQ_MODULE_ENABLED`:
+
+- `EloqStoreModule : eloq::EloqModule` exposes `ExtThdStart/ExtThdEnd`
+  (bind/unbind the thread-local `shard`), `Process(thd_id)` (run
+  `Shard::WorkOneRound`), and `HasTask(thd_id)`.
+- Shards own no threads; the host's workers drive shard progress. Shard
+  count must match the host's worker topology (`thd_id` ↔ `shard_id`).
+- Request sync waits switch from `std::atomic` wait to bthread
+  mutex/condvar so blocking a request doesn't block a host worker thread.
+- Shutdown is cooperative: shards are flagged `Stopping` and the host's
+  workers run rounds until each reports `Stopped` (see
+  `EloqStore::CleanupRuntime`).
+
+When changing `Shard::WorkLoop`, mirror the change in `WorkOneRound` — they
+are the same scheduler in two drive modes.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,46 @@
+# EloqStore Architecture Docs
+
+This directory is the canonical high-level documentation of EloqStore's design.
+It exists so that a developer (or an AI coding assistant) can build an accurate
+mental model of the engine without re-deriving it from 40k+ lines of C++.
+
+## Maintenance policy
+
+**These docs are part of the code.** When a change alters behavior described
+here — a new request type, a manifest format change, a new KvOptions field, a
+different GC rule, a renamed class — update the matching doc in the same PR.
+Each doc lists the source files it describes; if you touch those files in a
+way that changes the documented contract, the doc is stale until you fix it.
+
+Docs describe *durable design*: ownership, invariants, formats, and contracts.
+Do not record transient implementation trivia that the code states better.
+
+## Reading order
+
+| Doc | Covers |
+|-----|--------|
+| [01-overview.md](01-overview.md) | What EloqStore is, core concepts and glossary, repo layout, store modes |
+| [02-runtime-and-lifecycle.md](02-runtime-and-lifecycle.md) | `EloqStore` ownership graph, `KvOptions`, startup/shutdown ordering |
+| [03-request-api.md](03-request-api.md) | `KvRequest` family, sync/async completion, routing and fanout, retry rules |
+| [04-execution-model.md](04-execution-model.md) | Shard threads, coroutine tasks, task pools, per-table write serialization |
+| [05-btree-and-page-formats.md](05-btree-and-page-formats.md) | COW B+-tree, on-disk page encodings, in-memory cached pages, buffer pool |
+| [06-persistence-and-recovery.md](06-persistence-and-recovery.md) | RootMeta, page mapping, manifest format, replay, terms, branches, archives, file naming |
+| [07-io-stack.md](07-io-stack.md) | `AsyncIoManager` hierarchy: io_uring base, cloud overlay, standby overlay; FD cache; cloud transport |
+| [08-data-lifecycle.md](08-data-lifecycle.md) | Read/scan/write paths, compaction, TTL, file GC, archives, prewarm |
+| [09-large-values-zero-copy.md](09-large-values-zero-copy.md) | Segment files, `GlobalRegisteredMemory`, KV-cache pinned mode, metadata trailers |
+| [10-bindings-and-embedding.md](10-bindings-and-embedding.md) | C ABI, Rust/Python SDKs, EloqModule embedding mode |
+
+If you are about to modify code and want the minimum context: read 01, then
+the doc matching the subsystem you are touching. 04 (execution model) is
+prerequisite reading for any change inside `src/` — almost every correctness
+property in this codebase leans on shard-thread affinity.
+
+## Relationship to other docs
+
+- `docs/zero_copy_*.md` are the original *design proposals* for the
+  very-large-value feature. They predate the final implementation and contain
+  superseded details (e.g. the free-list described there uses a Harris-mark
+  scheme; the shipped code uses a version-tagged Treiber stack). Doc 09 here
+  reflects the code as written.
+- `.codex/knowledge-base/` is an older generated knowledge base; parts of it
+  reference files that no longer exist. Prefer this directory.


### PR DESCRIPTION
## What

Adds `docs/architecture/` — a maintained, code-accurate set of design docs — plus a root `CLAUDE.md` for AI coding assistants.

### docs/architecture/ (11 docs, ~1150 lines)

| Doc | Covers |
|-----|--------|
| `README.md` | Index, reading order, **maintenance policy** (update the matching doc in the same PR when code changes documented behavior) |
| `01-overview.md` | Core concepts/glossary, store modes, append vs in-place write modes, repo layout |
| `02-runtime-and-lifecycle.md` | `EloqStore` ownership graph, `Start()`/`Stop()` ordering, `KvOptions` |
| `03-request-api.md` | `KvRequest` family, sync/async completion contract, routing/fanout, auto-reopen & OOM retries |
| `04-execution-model.md` | Shard-thread affinity, work loop, coroutine tasks, per-partition write serialization |
| `05-btree-and-page-formats.md` | CoW B+-tree, on-disk page encodings, swizzled cached pages, buffer pool |
| `06-persistence-and-recovery.md` | RootMeta / page mapping / manifest format, replay, terms, branches, archives, file naming |
| `07-io-stack.md` | `IouringMgr` → `CloudStoreMgr` / `StandbyStoreMgr` layering, FD cache, cloud transport, standby rsync |
| `08-data-lifecycle.md` | Read/scan/write paths, compaction, TTL, file GC (retained sets + BranchGuard), prewarm |
| `09-large-values-zero-copy.md` | Segment files, `GlobalRegisteredMemory`, KV-cache pinned mode, metadata trailers, tail scratch |
| `10-bindings-and-embedding.md` | C ABI → Rust/Python SDK layering, `EloqModule` embedding mode |

### CLAUDE.md

Build/test/format commands (incl. MinIO setup, per-test binaries, memlock requirements for `large_value_*` tests), a condensed invariant list, and instructions to read `docs/architecture/` first and keep it updated alongside code changes.

## Why

- New contributors and AI assistants currently have to re-derive the design from ~40k lines of C++; these docs record the ownership graph, formats, and invariants the code only implies.
- Existing references are stale: `.codex/knowledge-base/` points at files that no longer exist (`mem_index_page.h`, `index_page_manager.h`), and `docs/zero_copy_read.md` describes a Harris-mark free list while the shipped `GlobalRegisteredMemory` uses a version-tagged Treiber stack. All content here was written from the current source; each doc lists the files it describes.

## Notes

- Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)