### PR TITLE
fix(eloqstore): recycle cached index pages on table erase to prevent UAF

### DIFF
--- a/include/storage/root_meta.h
+++ b/include/storage/root_meta.h
@@ -188,6 +188,10 @@ public:
 
     std::pair<Entry *, bool> GetOrCreate(const TableIdent &tbl_id);
     Entry *Find(const TableIdent &tbl_id);
+    // Plain lookup that does NOT run ProcessPendingErase(). Used by
+    // PageManager::RecyclePage(), which must not trigger deferred table erase
+    // (it can run inside Erase() and would re-enter the erase logic).
+    Entry *FindNoErase(const TableIdent &tbl_id);
     void Erase(const TableIdent &tbl_id);
 
     void Pin(Entry *entry);

--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -787,7 +787,11 @@ bool PageManager::Evict()
 bool PageManager::RecyclePage(MemCachedPage *page)
 {
     assert(!page->IsPinned());
-    RootMetaMgr::Entry *entry = root_meta_mgr_.Find(*page->tbl_ident_);
+    // FindNoErase, not Find: RecyclePage() runs during eviction and inside
+    // RootMetaMgr::Erase(); triggering ProcessPendingErase() here would
+    // re-enter the erase logic and could destroy the entry being erased
+    // underneath us.
+    RootMetaMgr::Entry *entry = root_meta_mgr_.FindNoErase(*page->tbl_ident_);
     if (entry != nullptr)
     {
         RootMeta &meta = entry->meta_;

--- a/src/storage/root_meta.cpp
+++ b/src/storage/root_meta.cpp
@@ -229,15 +229,20 @@ std::pair<RootMetaMgr::Entry *, bool> RootMetaMgr::GetOrCreate(
     return {entry, inserted};
 }
 
-RootMetaMgr::Entry *RootMetaMgr::Find(const TableIdent &tbl_id)
+RootMetaMgr::Entry *RootMetaMgr::FindNoErase(const TableIdent &tbl_id)
 {
-    ProcessPendingErase();
     auto it = entries_.find(tbl_id);
     if (it == entries_.end())
     {
         return nullptr;
     }
     return &it->second;
+}
+
+RootMetaMgr::Entry *RootMetaMgr::Find(const TableIdent &tbl_id)
+{
+    ProcessPendingErase();
+    return FindNoErase(tbl_id);
 }
 
 void RootMetaMgr::Erase(const TableIdent &tbl_id)
@@ -250,6 +255,33 @@ void RootMetaMgr::Erase(const TableIdent &tbl_id)
 
     Entry *entry = &it->second;
     CHECK(entry->meta_.ref_cnt_ == 0);
+
+    // Recycle the index pages still cached for this table before destroying the
+    // entry. Each MemCachedPage::tbl_ident_ points at this entry's tbl_id_;
+    // erasing the entry without recycling them leaves orphaned pages on the
+    // PageManager active list with a dangling tbl_ident_, so the next
+    // AllocPage()->Evict()->RecyclePage() dereferences freed memory and
+    // crashes. BatchWriteTask::Drop() clears the RootMeta but cannot recycle
+    // the pages itself (a yielded reader may still hold the root Handle then);
+    // here ref_cnt_ == 0, so no reader is mid-traversal and recycling is safe.
+    //
+    // The entry is still in entries_ here, so RecyclePage()'s
+    // root_meta_mgr_.FindNoErase(*page->tbl_ident_) resolves to this same valid
+    // entry (and, being a plain lookup, does not re-enter the erase logic).
+    // Snapshot into a vector first because RecyclePage() erases from
+    // cached_pages_ as it goes.
+    RootMeta &meta = entry->meta_;
+    if (!meta.cached_pages_.empty())
+    {
+        std::vector<MemCachedPage *> pages(meta.cached_pages_.begin(),
+                                           meta.cached_pages_.end());
+        for (MemCachedPage *page : pages)
+        {
+            owner_->RecyclePage(page);
+        }
+        meta.cached_pages_.clear();
+    }
+
     Dequeue(entry);
     used_bytes_ -= entry->bytes_;
     entries_.erase(it);


### PR DESCRIPTION
Dropping a table could later crash the store with a SIGSEGV in PageManager::RecyclePage -> RootMetaMgr::Find -> boost::hash<std::string>, hashing a TableIdent whose string data pointer is garbage.

Root cause: BatchWriteTask::Drop() clears the table's in-memory RootMeta (mapper_, mapping_snapshots_, ...) but leaves its already-cached index pages on the PageManager active list. Each MemCachedPage::tbl_ident_ points at the entry's tbl_id_ (set via MakeCowRoot with &entry->tbl_id_). When the now-empty entry is later erased (deferred Erase via Unpin -> pending_erase_), entries_.erase() frees that TableIdent, leaving the orphaned pages with a dangling tbl_ident_. The next AllocPage() -> Evict() -> RecyclePage() that selects such a page dereferences the freed TableIdent and crashes. A small buffer pool makes eviction fire on nearly every write, turning the latent use-after-free into a deterministic crash (CI smoke ran with a 1MB buffer pool).

Fix: RootMetaMgr::Erase() now recycles the entry's cached_pages_ before destroying it. ref_cnt_ == 0 at that point, so no reader is mid-traversal and recycling is safe; the entry is still in entries_, so the recycle can resolve the page's owner. Drop() itself cannot do this because a yielded reader may still hold the root Handle.

To recycle from within Erase() without re-entering the deferred-erase logic, add RootMetaMgr::FindNoErase() (a plain lookup that does not run ProcessPendingErase()) and have PageManager::RecyclePage() use it instead of Find(). RecyclePage() is a low-level page operation and should not drive table-erase GC on every eviction anyway.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page recycling logic during table erasure to prevent potential re-entry issues, enhancing overall system stability and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->