### PR TITLE
fix: roll back branch file-id high-water on aborted writes

### DIFF
--- a/include/async_io_manager.h
+++ b/include/async_io_manager.h
@@ -481,6 +481,22 @@ public:
         return empty;
     }
 
+    // Roll back the tail of a table's BranchFileMapping to a pre-write-task
+    // snapshot (size + the tail's two high-water marks). Used by
+    // WriteTask::Abort() to undo the file-id high-water advances an aborted
+    // task made via SetBranchFileIdTerm, so a subsequent write does not
+    // regress.
+    virtual void RollbackBranchFileTail(const TableIdent &tbl_id,
+                                        size_t pre_size,
+                                        FileId pre_max_file_id,
+                                        FileId pre_max_segment_file_id)
+    {
+        (void) tbl_id;
+        (void) pre_size;
+        (void) pre_max_file_id;
+        (void) pre_max_segment_file_id;
+    }
+
     virtual uint64_t ProcessTerm() const
     {
         return 0;
@@ -609,6 +625,12 @@ public:
     // Return the current BranchFileMapping for a table.
     const BranchFileMapping &GetBranchFileMapping(
         const TableIdent &tbl_id) override;
+
+    // Roll back a table's BranchFileMapping tail to a pre-write-task snapshot.
+    void RollbackBranchFileTail(const TableIdent &tbl_id,
+                                size_t pre_size,
+                                FileId pre_max_file_id,
+                                FileId pre_max_segment_file_id) override;
 
     // Process term management for term-aware file naming.
     // Local mode always returns 0.

--- a/include/fail_point.h
+++ b/include/fail_point.h
@@ -2,14 +2,16 @@
 
 #include <cstring>
 
-// Test-only error injection. Unlike KillPoint (kill_point.h), which SIGTERMs the
-// process to exercise crash-recovery paths, FailPoint makes a code path return
-// an error so tests can drive in-process error/abort handling (e.g. verifying
-// WriteTask::Abort rolls back the BranchFileMapping high-water marks).
+// Test-only error injection. Unlike KillPoint (kill_point.h), which SIGTERMs
+// the process to exercise crash-recovery paths, FailPoint makes a code path
+// return an error so tests can drive in-process error/abort handling (e.g.
+// verifying WriteTask::Abort rolls back the BranchFileMapping high-water
+// marks).
 //
 // Usage: arm a named point from the test, then a TEST_FAIL_POINT_RETURN(name,
-// err) embedded in engine code returns `err` exactly once before auto-disarming.
-// Compiled out entirely in release (NDEBUG) builds, like the kill-point macros.
+// err) embedded in engine code returns `err` exactly once before
+// auto-disarming. Compiled out entirely in release (NDEBUG) builds, like the
+// kill-point macros.
 #ifndef NDEBUG
 #define TEST_FAIL_POINT_RETURN(name, err)                           \
     do                                                              \

--- a/include/fail_point.h
+++ b/include/fail_point.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstring>
+
+// Test-only error injection. Unlike KillPoint (kill_point.h), which SIGTERMs the
+// process to exercise crash-recovery paths, FailPoint makes a code path return
+// an error so tests can drive in-process error/abort handling (e.g. verifying
+// WriteTask::Abort rolls back the BranchFileMapping high-water marks).
+//
+// Usage: arm a named point from the test, then a TEST_FAIL_POINT_RETURN(name,
+// err) embedded in engine code returns `err` exactly once before auto-disarming.
+// Compiled out entirely in release (NDEBUG) builds, like the kill-point macros.
+#ifndef NDEBUG
+#define TEST_FAIL_POINT_RETURN(name, err)                           \
+    do                                                              \
+    {                                                               \
+        if (::eloqstore::FailPoint::GetInstance().ShouldFail(name)) \
+        {                                                           \
+            return (err);                                           \
+        }                                                           \
+    } while (0)
+#else
+#define TEST_FAIL_POINT_RETURN(name, err) \
+    do                                    \
+    {                                     \
+    } while (0)
+#endif
+
+namespace eloqstore
+{
+// Trivially destructible (no global/static dtor work): point names are string
+// literals with static storage duration, so a const char* is sufficient.
+class FailPoint
+{
+public:
+    static FailPoint &GetInstance()
+    {
+        static FailPoint instance;
+        return instance;
+    }
+
+    // Arm so the next ShouldFail(name) returns true once, then auto-disarms.
+    // @p name must be a string literal (stored by pointer, not copied).
+    void ArmOnce(const char *name)
+    {
+        armed_ = name;
+    }
+
+    void Disarm()
+    {
+        armed_ = nullptr;
+    }
+
+    bool ShouldFail(const char *name)
+    {
+        if (armed_ == nullptr || std::strcmp(armed_, name) != 0)
+        {
+            return false;
+        }
+        armed_ = nullptr;  // fire once
+        return true;
+    }
+
+private:
+    const char *armed_{nullptr};
+};
+}  // namespace eloqstore

--- a/include/tasks/write_task.h
+++ b/include/tasks/write_task.h
@@ -159,9 +159,16 @@ protected:
     KvError WritePage(VarPage page, FilePageId file_page_id);
     KvError AppendWritePage(VarPage page, FilePageId file_page_id);
     void FlushAppendWrites();
-    // Capture pre_branch_tail_ on this task's first file-id allocation so
-    // Abort() can roll back the BranchFileMapping high-water advances.
-    void SnapshotBranchTailIfNeeded();
+    // Build this task's CoW root and snapshot the branch-file-mapping tail in
+    // one step: forwards to PageManager::MakeCowRoot, and on success captures
+    // the tail (before any allocation can advance it) so Abort() can roll the
+    // BranchFileMapping high-water marks back. On failure returns the
+    // PageManager error without capturing. Call this instead of
+    // shard->IndexManager()->MakeCowRoot() from write paths.
+    KvError MakeCowRoot();
+    // Capture pre_branch_tail_ once, from MakeCowRoot() at task start. Asserts
+    // it has not already been captured this task (Reset() clears it).
+    void SnapshotBranchTail();
     KvError WaitPendingUploads();
     KvError ConsumePendingUploadResults();
     std::pair<FileId, uint32_t> ConvFilePageId(FilePageId file_page_id) const;
@@ -191,14 +198,14 @@ protected:
     // next write to allocate a lower file id than the recorded max and trip the
     // ascending-order CHECK. A task only ever touches the tail, so remembering
     // the pre-task size and the tail's two maxima is enough to undo it -- no
-    // need to copy the whole mapping. size == kNotCaptured means not captured
+    // need to copy the whole mapping. size_ == kNotCaptured means not captured
     // yet.
     struct BranchTailSnapshot
     {
         static constexpr size_t kNotCaptured = ~size_t{0};
-        size_t size{kNotCaptured};
-        FileId max_file_id{0};
-        FileId max_segment_file_id{0};
+        size_t size_{kNotCaptured};
+        FileId max_file_id_{0};
+        FileId max_segment_file_id_{0};
     };
     BranchTailSnapshot pre_branch_tail_;
 

--- a/include/tasks/write_task.h
+++ b/include/tasks/write_task.h
@@ -159,6 +159,9 @@ protected:
     KvError WritePage(VarPage page, FilePageId file_page_id);
     KvError AppendWritePage(VarPage page, FilePageId file_page_id);
     void FlushAppendWrites();
+    // Capture pre_branch_tail_ on this task's first file-id allocation so
+    // Abort() can roll back the BranchFileMapping high-water advances.
+    void SnapshotBranchTailIfNeeded();
     KvError WaitPendingUploads();
     KvError ConsumePendingUploadResults();
     std::pair<FileId, uint32_t> ConvFilePageId(FilePageId file_page_id) const;
@@ -179,6 +182,26 @@ protected:
     // segments land in the same file (the common case in batched writes
     // and compaction rewrites).
     std::optional<FileId> last_seen_segment_file_id_;
+
+    // Pre-task snapshot of this table's BranchFileMapping tail, captured before
+    // the first file-id stamp. AllocatePage/AllocateSegment advance the tail's
+    // max_file_id_/max_segment_file_id_ via SetBranchFileIdTerm (or append one
+    // new (branch, term) entry). Abort() discards the CoW allocator but those
+    // high-water marks live in IoMgr and would otherwise survive, leaving the
+    // next write to allocate a lower file id than the recorded max and trip the
+    // ascending-order CHECK. A task only ever touches the tail, so remembering
+    // the pre-task size and the tail's two maxima is enough to undo it -- no
+    // need to copy the whole mapping. size == kNotCaptured means not captured
+    // yet.
+    struct BranchTailSnapshot
+    {
+        static constexpr size_t kNotCaptured = ~size_t{0};
+        size_t size{kNotCaptured};
+        FileId max_file_id{0};
+        FileId max_segment_file_id{0};
+    };
+    BranchTailSnapshot pre_branch_tail_;
+
     WriteBufferAggregator append_aggregator_{0};
     UploadState upload_state_;
     uint32_t inflight_upload_tasks_{0};

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -53,6 +53,7 @@
 #include "coding.h"
 #include "common.h"
 #include "eloq_store.h"
+#include "fail_point.h"
 #include "kill_point.h"
 #include "kv_options.h"
 #include "standby_service.h"
@@ -1843,6 +1844,33 @@ void IouringMgr::SetBranchFileMapping(const TableIdent &tbl_id,
                                       BranchFileMapping mapping)
 {
     branch_file_mapping_[tbl_id] = std::move(mapping);
+}
+
+void IouringMgr::RollbackBranchFileTail(const TableIdent &tbl_id,
+                                        size_t pre_size,
+                                        FileId pre_max_file_id,
+                                        FileId pre_max_segment_file_id)
+{
+    auto it = branch_file_mapping_.find(tbl_id);
+    if (it == branch_file_mapping_.end())
+    {
+        return;
+    }
+    BranchFileMapping &mapping = it->second;
+    // Drop the (branch, term) entries this aborted task appended (at most one,
+    // but pop defensively until the size matches the snapshot).
+    while (mapping.size() > pre_size)
+    {
+        mapping.pop_back();
+    }
+    // Restore the surviving tail's high-water marks; the task had extended them
+    // in place. When pre_size == 0 the mapping was empty before the task, so
+    // there is nothing left to restore after the pops above.
+    if (pre_size > 0 && !mapping.empty())
+    {
+        mapping.back().max_file_id_ = pre_max_file_id;
+        mapping.back().max_segment_file_id_ = pre_max_segment_file_id;
+    }
 }
 
 std::string_view IouringMgr::InternBranchName(std::string_view name)
@@ -5555,7 +5583,24 @@ KvError CloudStoreMgr::SyncFile(LruFD::Ref fd)
 KvError CloudStoreMgr::SyncFiles(const TableIdent &tbl_id,
                                  std::span<LruFD::Ref> fds)
 {
-    if (options_->data_append_mode && CurrentWriteTask() != nullptr)
+    // Test seam: lets a test force a write task to abort at the flush step
+    // (after it has allocated files and advanced the branch high-water) without
+    // crashing the process, to exercise WriteTask::Abort's rollback.
+    TEST_FAIL_POINT_RETURN("SyncFiles", KvError::Corrupted);
+
+    // The "at most one dirty data file per write task" invariant only holds
+    // when the write-buffer pool is active. With the pool, AppendWritePage
+    // seals each completed data file (uploads it and clears its dirty flag, see
+    // OnDataFileSealed) as the write crosses into the next file, so only the
+    // tail file is left dirty here. Without the pool (HasWriteBufferPool() ==
+    // false) writes take the direct path with no per-file sealing, so a single
+    // write task that legitimately spans several data files -- e.g. a large
+    // overflow value -- leaves all of them dirty, and they are all uploaded
+    // together below. Only enforce the guard when the sealing path is in
+    // effect; firing it otherwise turns a valid large-value write into a
+    // spurious Corrupted/abort.
+    if (options_->data_append_mode && HasWriteBufferPool() &&
+        CurrentWriteTask() != nullptr)
     {
         size_t dirty_data_files = 0;
         for (LruFD::Ref fd : fds)

--- a/src/tasks/background_write.cpp
+++ b/src/tasks/background_write.cpp
@@ -102,7 +102,7 @@ KvError BackgroundWrite::Compact()
     const KvOptions *opts = Options();
 
     LOG(INFO) << "begin compaction on " << tbl_ident_;
-    KvError err = shard->IndexManager()->MakeCowRoot(tbl_ident_, cow_meta_);
+    KvError err = MakeCowRoot();
     CHECK_KV_ERR(err);
 
     // Short-circuit when there is nothing to compact and nothing to GC:

--- a/src/tasks/batch_write_task.cpp
+++ b/src/tasks/batch_write_task.cpp
@@ -253,7 +253,7 @@ KvError BatchWriteTask::Apply()
 {
     // directly go to low priority queue and wait for scheduling
     YieldToLowPQ();
-    KvError err = shard->IndexManager()->MakeCowRoot(tbl_ident_, cow_meta_);
+    KvError err = MakeCowRoot();
     cow_meta_.compression_->SampleAndBuildDictionaryIfNeeded(data_batch_);
     CHECK_KV_ERR(err);
     err = ApplyBatch(cow_meta_.root_id_, true);
@@ -1831,7 +1831,7 @@ std::pair<MemCachedPage::Handle, KvError> BatchWriteTask::TruncateIndexPage(
 
 KvError BatchWriteTask::Truncate(std::string_view trunc_pos)
 {
-    KvError err = shard->IndexManager()->MakeCowRoot(tbl_ident_, cow_meta_);
+    KvError err = MakeCowRoot();
     CHECK_KV_ERR(err);
     if (cow_meta_.root_id_ == MaxPageId)
     {
@@ -2048,7 +2048,7 @@ KvError BatchWriteTask::CleanExpiredKeys()
         return KvError::NoError;
     }
 
-    err = shard->IndexManager()->MakeCowRoot(tbl_ident_, cow_meta_);
+    err = MakeCowRoot();
     CHECK_KV_ERR(err);
     assert(cow_meta_.next_expire_ts_ != 0 &&
            cow_meta_.next_expire_ts_ <= now_ts_ms);

--- a/src/tasks/write_task.cpp
+++ b/src/tasks/write_task.cpp
@@ -182,7 +182,7 @@ void WriteTask::Reset(const TableIdent &tbl_id)
     seg_mapping_deltas_.clear();
     last_append_file_id_.reset();
     last_seen_segment_file_id_.reset();
-    pre_branch_tail_.size = BranchTailSnapshot::kNotCaptured;
+    pre_branch_tail_.size_ = BranchTailSnapshot::kNotCaptured;
     cow_meta_ = CowRootMeta();
     size_t buf_size = Options()->write_buffer_size;
     if (buf_size == 0)
@@ -212,13 +212,13 @@ void WriteTask::Abort()
     // Roll back the BranchFileMapping high-water marks this task advanced. The
     // CoW allocator is discarded below, so without this the branch tail would
     // stay ahead of it and the next write would regress the file-id order.
-    if (pre_branch_tail_.size != BranchTailSnapshot::kNotCaptured)
+    if (pre_branch_tail_.size_ != BranchTailSnapshot::kNotCaptured)
     {
         IoMgr()->RollbackBranchFileTail(tbl_ident_,
-                                        pre_branch_tail_.size,
-                                        pre_branch_tail_.max_file_id,
-                                        pre_branch_tail_.max_segment_file_id);
-        pre_branch_tail_.size = BranchTailSnapshot::kNotCaptured;
+                                        pre_branch_tail_.size_,
+                                        pre_branch_tail_.max_file_id_,
+                                        pre_branch_tail_.max_segment_file_id_);
+        pre_branch_tail_.size_ = BranchTailSnapshot::kNotCaptured;
     }
 
     if (cow_meta_.old_mapping_ != nullptr)
@@ -503,22 +503,28 @@ KvError WriteTask::WaitWrite()
     return err;
 }
 
-void WriteTask::SnapshotBranchTailIfNeeded()
+KvError WriteTask::MakeCowRoot()
 {
-    // Invoked on every file-id allocation but captures only once per task (on
-    // the first); mark the capture branch cold so the steady-state path stays
-    // cheap.
-    if (__builtin_expect(
-            pre_branch_tail_.size == BranchTailSnapshot::kNotCaptured, 0))
+    KvError err = shard->IndexManager()->MakeCowRoot(tbl_ident_, cow_meta_);
+    CHECK_KV_ERR(err);
+    SnapshotBranchTail();
+    return KvError::NoError;
+}
+
+void WriteTask::SnapshotBranchTail()
+{
+    // Called exactly once per task, from MakeCowRoot(), before any allocation
+    // can advance the branch tail. Abort() rolls the BranchFileMapping
+    // high-water marks back to this captured value. Reset() leaves size_ at
+    // kNotCaptured at task start, and each task makes exactly one CoW root, so
+    // a second capture would mean a clobbered snapshot -- assert against it.
+    assert(pre_branch_tail_.size_ == BranchTailSnapshot::kNotCaptured);
+    const BranchFileMapping &m = IoMgr()->GetBranchFileMapping(tbl_ident_);
+    pre_branch_tail_.size_ = m.size();
+    if (!m.empty())
     {
-        const BranchFileMapping &m = IoMgr()->GetBranchFileMapping(tbl_ident_);
-        pre_branch_tail_.size = m.size();
-        if (!m.empty())
-        {
-            pre_branch_tail_.max_file_id = m.back().max_file_id_;
-            pre_branch_tail_.max_segment_file_id =
-                m.back().max_segment_file_id_;
-        }
+        pre_branch_tail_.max_file_id_ = m.back().max_file_id_;
+        pre_branch_tail_.max_segment_file_id_ = m.back().max_segment_file_id_;
     }
 }
 
@@ -570,7 +576,6 @@ std::pair<PageId, FilePageId> WriteTask::AllocatePage(PageId page_id)
     FilePageId file_page_id = cow_meta_.mapper_->FilePgAllocator()->Allocate();
     FileId file_id_after_allocate =
         cow_meta_.mapper_->FilePgAllocator()->CurrentFileId();
-    SnapshotBranchTailIfNeeded();
     std::string unused_branch;
     uint64_t unused_term;
     if (!IoMgr()->GetBranchNameAndTerm(tbl_ident_,
@@ -608,8 +613,6 @@ std::pair<PageId, FilePageId> WriteTask::AllocateSegment(PageId page_id)
     FileId file_id_before = seg_mapper->FilePgAllocator()->CurrentFileId();
     FilePageId file_page_id = seg_mapper->FilePgAllocator()->Allocate();
     FileId file_id_after = seg_mapper->FilePgAllocator()->CurrentFileId();
-
-    SnapshotBranchTailIfNeeded();
 
     // After a restart with a new term, the allocator is bumped to a new file
     // whose (branch, term) hasn't been recorded yet. Stamp it on first

--- a/src/tasks/write_task.cpp
+++ b/src/tasks/write_task.cpp
@@ -182,6 +182,7 @@ void WriteTask::Reset(const TableIdent &tbl_id)
     seg_mapping_deltas_.clear();
     last_append_file_id_.reset();
     last_seen_segment_file_id_.reset();
+    pre_branch_tail_.size = BranchTailSnapshot::kNotCaptured;
     cow_meta_ = CowRootMeta();
     size_t buf_size = Options()->write_buffer_size;
     if (buf_size == 0)
@@ -207,6 +208,18 @@ void WriteTask::Abort()
     // Always invoke AbortWrite so CloudStoreMgr can clear per-table upload
     // segments and io manager can reset dirty state.
     IoMgr()->AbortWrite(tbl_ident_);
+
+    // Roll back the BranchFileMapping high-water marks this task advanced. The
+    // CoW allocator is discarded below, so without this the branch tail would
+    // stay ahead of it and the next write would regress the file-id order.
+    if (pre_branch_tail_.size != BranchTailSnapshot::kNotCaptured)
+    {
+        IoMgr()->RollbackBranchFileTail(tbl_ident_,
+                                        pre_branch_tail_.size,
+                                        pre_branch_tail_.max_file_id,
+                                        pre_branch_tail_.max_segment_file_id);
+        pre_branch_tail_.size = BranchTailSnapshot::kNotCaptured;
+    }
 
     if (cow_meta_.old_mapping_ != nullptr)
     {
@@ -490,6 +503,25 @@ KvError WriteTask::WaitWrite()
     return err;
 }
 
+void WriteTask::SnapshotBranchTailIfNeeded()
+{
+    // Invoked on every file-id allocation but captures only once per task (on
+    // the first); mark the capture branch cold so the steady-state path stays
+    // cheap.
+    if (__builtin_expect(
+            pre_branch_tail_.size == BranchTailSnapshot::kNotCaptured, 0))
+    {
+        const BranchFileMapping &m = IoMgr()->GetBranchFileMapping(tbl_ident_);
+        pre_branch_tail_.size = m.size();
+        if (!m.empty())
+        {
+            pre_branch_tail_.max_file_id = m.back().max_file_id_;
+            pre_branch_tail_.max_segment_file_id =
+                m.back().max_segment_file_id_;
+        }
+    }
+}
+
 std::pair<PageId, FilePageId> WriteTask::AllocatePage(PageId page_id)
 {
     if (page_id != MaxPageId)
@@ -538,6 +570,7 @@ std::pair<PageId, FilePageId> WriteTask::AllocatePage(PageId page_id)
     FilePageId file_page_id = cow_meta_.mapper_->FilePgAllocator()->Allocate();
     FileId file_id_after_allocate =
         cow_meta_.mapper_->FilePgAllocator()->CurrentFileId();
+    SnapshotBranchTailIfNeeded();
     std::string unused_branch;
     uint64_t unused_term;
     if (!IoMgr()->GetBranchNameAndTerm(tbl_ident_,
@@ -575,6 +608,8 @@ std::pair<PageId, FilePageId> WriteTask::AllocateSegment(PageId page_id)
     FileId file_id_before = seg_mapper->FilePgAllocator()->CurrentFileId();
     FilePageId file_page_id = seg_mapper->FilePgAllocator()->Allocate();
     FileId file_id_after = seg_mapper->FilePgAllocator()->CurrentFileId();
+
+    SnapshotBranchTailIfNeeded();
 
     // After a restart with a new term, the allocator is bumped to a new file
     // whose (branch, term) hasn't been recorded yet. Stamp it on first

--- a/tests/persist.cpp
+++ b/tests/persist.cpp
@@ -14,6 +14,7 @@
 
 #include "common.h"
 #include "error.h"
+#include "fail_point.h"
 #include "kv_options.h"
 #include "test_utils.h"
 #include "types.h"
@@ -428,6 +429,63 @@ TEST_CASE("append mode with restart", "[persist]")
             tbl->Validate();
         }
     }
+}
+
+TEST_CASE("write an overflow page without a write buffer pool (cloud)",
+          "[persist][overflow_kv][cloud]")
+{
+    eloqstore::KvOptions options = cloud_options;
+    options.buffer_pool_size = 1 * eloqstore::MB;  // 1MB buffer pool
+    options.pages_per_file_shift = 0;              // one 4K page per data file
+    eloqstore::EloqStore *store = InitStore(options);
+
+    const eloqstore::TableIdent tbl_id{"overflow-no-wbuf-cloud", 0};
+
+    MapVerifier verify(tbl_id, store);
+    verify.SetValueSize(20 * 1024);  // 20K value (stored via overflow pages)
+
+    // Write the 20K key-value once. MapVerifier::Upsert asserts the write
+    // returns NoError and validates the readback.
+    constexpr uint64_t kKey = 1;
+    verify.Upsert(kKey);
+}
+
+// A write task that aborts after advancing the BranchFileMapping file-id
+// high-water must roll that advance back. Otherwise the next write to the same
+// table allocates a lower file id than the stale recorded max and trips the
+// ascending-order CHECK in SetBranchFileIdTerm (which aborts the process). The
+// SyncFiles fail point forces the abort deterministically; the tiny data files
+// (one 4K page each) make the first write span several files so its high-water
+// is well past file 0.
+TEST_CASE("write task abort rolls back branch file-id high-water (cloud)",
+          "[persist][overflow_kv][cloud][abort]")
+{
+    eloqstore::KvOptions options = cloud_options;
+    options.buffer_pool_size = 1 * eloqstore::MB;  // no write-buffer pool
+    options.pages_per_file_shift = 0;              // one 4K page per data file
+    eloqstore::EloqStore *store = InitStore(options);
+
+    const eloqstore::TableIdent tbl_id{"abort-rollback-cloud", 0};
+
+    auto write = [&](uint64_t key, uint32_t value_len, uint64_t ts)
+    {
+        eloqstore::BatchWriteRequest req;
+        req.SetTableId(tbl_id);
+        req.AddWrite(
+            Key(key), Value(key, value_len), ts, eloqstore::WriteOp::Upsert);
+        store->ExecSync(&req);
+        return req.Error();
+    };
+
+    // Arm the flush fail point: the first SyncFiles returns Corrupted, aborting
+    // the write task after it has stamped file ids well past file 0.
+    eloqstore::FailPoint::GetInstance().ArmOnce("SyncFiles");
+    REQUIRE(write(1, 20 * 1024, 1) == eloqstore::KvError::Corrupted);
+    eloqstore::FailPoint::GetInstance().Disarm();
+
+    // The next write must succeed: Abort rolled the high-water back to its
+    // pre-task value. Without the rollback it regresses and aborts the process.
+    REQUIRE(write(2, 64, 2) == eloqstore::KvError::NoError);
 }
 
 TEST_CASE("append mode survives compression toggles across restarts",


### PR DESCRIPTION
Without an active write-buffer pool, a large overflow value takes the direct write path (no per-file sealing), so a single write task legitimately dirties several data files. CloudStoreMgr::SyncFiles rejected that as Corrupted and aborted the task. The abort discarded the CoW allocator but left the BranchFileMapping high-water marks advanced, so the next write allocated a lower file id than the recorded max and tripped the ascending-order CHECK in SetBranchFileIdTerm (process abort).

- Gate the "one dirty data file per write task" guard on HasWriteBufferPool(); the invariant only holds when AppendWritePage seals each completed file. Without the pool the dirty files are uploaded together.
- WriteTask::Abort() rolls the BranchFileMapping tail back to a snapshot captured before the task's first file-id stamp.
- Add a Debug-only FailPoint error-injection seam and a regression test.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for large values via overflow page allocation, allowing writes to span multiple data files.
  * Strengthened “abort” recovery for write operations by rolling back branch file-tail high-water marks to the pre-write state.

* **Bug Fixes**
  * Improved cloud-mode abort handling to restore file-id state correctly after failures (including sync-related aborts).
  * Refined corruption detection to trigger only under the relevant write/append conditions, reducing false corruption cases during large multi-file writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->