### PR TITLE
fix: skip transient manifest list entries instead of LOG(FATAL)

### DIFF
--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -4515,9 +4515,17 @@ std::pair<ManifestFilePtr, KvError> CloudStoreMgr::GetManifest(
         std::optional<std::string> tag;
         if (!ParseManifestFileSuffix(name, branch_name, term, tag))
         {
-            LOG(FATAL) << "CloudStoreMgr::GetManifest: failed to parse "
-                          "manifest file suffix: "
-                       << name;
+            // Not a valid manifest file name. The delimiter list may return
+            // a directory-style CommonPrefixes entry (ending with '/') when
+            // the manifest object is concurrently dropped: S3-compatible
+            // stores such as MinIO keep each object as a directory on disk,
+            // and a racing list can observe it without its metadata. The
+            // entry is transient; skip it. Each partition has a single
+            // owner, so a missing flat manifest means the manifest is being
+            // dropped and the partition is treated as absent.
+            LOG(WARNING) << "CloudStoreMgr::GetManifest: skip unrecognized "
+                            "entry under manifest prefix of table "
+                         << tbl_id << ": " << name;
             continue;
         }
 
@@ -4761,9 +4769,12 @@ std::pair<ManifestFilePtr, KvError> CloudStoreMgr::RefreshManifest(
                 std::optional<std::string> tag;
                 if (!ParseManifestFileSuffix(name, branch_name, term, tag))
                 {
-                    LOG(FATAL) << "CloudStoreMgr::RefreshManifest: failed to "
-                                  "parse manifest file suffix: "
-                               << name;
+                    // Transient directory-style entry from a racing drop;
+                    // see CloudStoreMgr::GetManifest for details.
+                    LOG(WARNING)
+                        << "CloudStoreMgr::RefreshManifest: skip unrecognized "
+                           "entry under manifest prefix of table "
+                        << tbl_id << ": " << name;
                     continue;
                 }
                 if (tag.has_value())

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -4460,6 +4460,10 @@ std::pair<ManifestFilePtr, KvError> CloudStoreMgr::GetManifest(
     do
     {
         ObjectStore::ListTask list_task(remote_path, false);
+        // Manifest keys are flat under the prefix; list without a delimiter
+        // so the response cannot carry directory-style CommonPrefixes
+        // entries (see the parse-failure skip below).
+        list_task.SetRecursive(true);
         list_task.SetContinuationToken(continuation_token);
         list_task.SetKvTask(current_task);
         AcquireCloudSlot(current_task);
@@ -4720,6 +4724,9 @@ std::pair<ManifestFilePtr, KvError> CloudStoreMgr::RefreshManifest(
             do
             {
                 ObjectStore::ListTask list_task(remote_path, false);
+                // Flat manifest keys; no delimiter so the response cannot
+                // carry CommonPrefixes entries (see GetManifest).
+                list_task.SetRecursive(true);
                 list_task.SetContinuationToken(continuation_token);
                 list_task.SetKvTask(current_task);
                 AcquireCloudSlot(current_task);


### PR DESCRIPTION
GetManifest/RefreshManifest list cloud manifests with delimiter=/. When the listing races with a concurrent manifest drop (e.g. FLUSHDB truncate dropping a table), S3-compatible stores such as MinIO - which keep each object as a directory on disk - can transiently report the half-deleted object as a directory-style CommonPrefixes entry like "main_2/". That name fails ParseManifestFileSuffix and the LOG(FATAL) aborted the whole node from a background local-file GC task, hanging the cluster (seen as a multi2 tcl test timeout in EloqKV CI).

Such entries are not files and are transient; skip them with a WARNING, matching how every other ParseManifestFileSuffix caller handles parse failures. The dead `continue` after the old LOG(FATAL) suggests skipping was the original intent. Since each partition has a single owner, the absence of a flat manifest file means the manifest is being dropped, so falling through to NotFound is correct.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud manifest handling when listings include non-standard directory-style entries.
  * Manifest selection and refresh now treat invalid manifest-suffix entries as warnings and skip them, preventing sync from stopping unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->