### PR TITLE
fix: surface promoted-manifest upload failure instead of tolerating it

### DIFF
--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -4613,18 +4613,37 @@ std::pair<ManifestFilePtr, KvError> CloudStoreMgr::GetManifest(
             return {nullptr, ToKvError(res)};
         }
 
-        // 2) Upload manifest_<branch>_<process_term> to cloud.
-        // (No need to delete the manifest file if failed to upload. The content
-        // of this manifest is same to the one on cloud and can be used on this
-        // read operation (without changing manifest content). The manifest with
-        // process_term will be uploaded on next write operation.)
-        KvError up_err = UploadFile(tbl_id, promoted_name, nullptr);
+        // 2) Upload manifest_<branch>_<process_term> to cloud. The promoted
+        // manifest must be durable in cloud before this term serves the
+        // partition: cloud GC prunes older-term manifests by name, so
+        // tolerating a failed upload leaves a window where the only cloud
+        // manifest can be deleted and the partition's metadata exists on
+        // local disk alone. Retry transient failures, then surface the
+        // error — the failing access is visible to the caller, and the next
+        // access re-enters the promote path (the re-download and rename are
+        // idempotent: the local promoted copy is byte-identical to the
+        // still-present cloud manifest) and retries the upload.
+        KvError up_err = KvError::NoError;
+        for (int attempt = 0; attempt < 3; ++attempt)
+        {
+            up_err = UploadFile(tbl_id, promoted_name, nullptr);
+            if (up_err == KvError::NoError ||
+                up_err == KvError::OssInsufficientStorage)
+            {
+                break;
+            }
+            LOG(WARNING) << "CloudStoreMgr::GetManifest: upload of promoted "
+                         << "manifest file " << promoted_name << " for table "
+                         << tbl_id << " failed: " << ErrorString(up_err)
+                         << ", retrying";
+        }
         if (up_err != KvError::NoError)
         {
             LOG(ERROR) << "CloudStoreMgr::GetManifest: failed to upload "
                        << "promoted manifest file " << promoted_name
                        << " for table " << tbl_id << " : "
                        << ErrorString(up_err);
+            return {nullptr, up_err};
         }
         // Update manifest_branch_term_ to the promoted term/branch.
     }

--- a/src/test_utils.cpp
+++ b/src/test_utils.cpp
@@ -875,9 +875,8 @@ void ConcurrencyTester::Run(uint16_t n_readers,
     while (running_readers > 0 || HasWriting())
     {
         uint64_t user_data;
-        bool dequeued =
-            finished_reqs_.wait_dequeue_timed(user_data,
-                                              std::chrono::seconds(5));
+        bool dequeued = finished_reqs_.wait_dequeue_timed(
+            user_data, std::chrono::seconds(5));
         auto now = std::chrono::steady_clock::now();
         if (now - last_report >= std::chrono::seconds(15))
         {

--- a/src/test_utils.cpp
+++ b/src/test_utils.cpp
@@ -3,6 +3,7 @@
 #include <sys/types.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <string>
@@ -792,6 +793,11 @@ void ConcurrencyTester::Init()
     for (Partition &partition : partitions_)
     {
         eloqstore::TableIdent tbl_id(tbl_name_, partition.id_);
+        // Progress marker: seeding large partitions dominates the test's
+        // wall time and is otherwise silent — a stall here would be
+        // indistinguishable from a hang in CI logs.
+        LOG(INFO) << "concurrency init: seeding partition " << partition.id_
+                  << "/" << partitions_.size() << " kvs=" << kvs_num;
 
         // Try to load partition KVs from EloqStore
         eloqstore::ScanRequest scan_req;
@@ -859,10 +865,34 @@ void ConcurrencyTester::Run(uint16_t n_readers,
         ExecRead(&reader);
     }
 
+    // Periodic progress heartbeat: the tester is otherwise silent between
+    // startup and shutdown, so a CI timeout log cannot distinguish a slow
+    // environment (counters keep advancing between heartbeats) from a
+    // genuine hang (identical heartbeats repeating, completed_reqs frozen).
+    uint64_t completed_reqs = 0;
+    auto last_report = std::chrono::steady_clock::now();
+
     while (running_readers > 0 || HasWriting())
     {
         uint64_t user_data;
-        finished_reqs_.wait_dequeue(user_data);
+        bool dequeued =
+            finished_reqs_.wait_dequeue_timed(user_data,
+                                              std::chrono::seconds(5));
+        auto now = std::chrono::steady_clock::now();
+        if (now - last_report >= std::chrono::seconds(15))
+        {
+            LOG(INFO) << "concurrency progress: completed_reqs="
+                      << completed_reqs << " readers=" << running_readers
+                      << " verify_kv=" << verify_kv_
+                      << " verify_sum=" << verify_sum_
+                      << " has_writing=" << HasWriting();
+            last_report = now;
+        }
+        if (!dequeued)
+        {
+            continue;
+        }
+        completed_reqs++;
         bool is_write = (user_data & (uint64_t(1) << 63));
         uint32_t id = (user_data & ((uint64_t(1) << 63) - 1));
 


### PR DESCRIPTION

After a failover the new process (term T2) promotes the partition's manifest by renaming the downloaded manifest_<branch>_T1 locally to manifest_<branch>_T2 and uploading it as a new cloud object. The upload failure used to be tolerated with only a log line, on the assumption that the next write would re-upload it.

That assumption leaves a durability hole:

- Cloud GC prunes superseded manifests by the term in the object name: any manifest_<branch>_<term> with term < process_term is deleted, without checking that manifest_<branch>_<process_term> actually exists in cloud. While the T2 upload has not succeeded, the T1 object is not superseded — it is the only cloud copy of the partition's metadata — yet GC (triggered periodically by the archive crond, no write required) will delete it.
- After that the partition has zero manifests in cloud. The window closes only on the next write to the partition (the write path uploads the dirty manifest with retry-until-success), so for a read-only or idle partition after failover it stays open indefinitely. Losing the local disk during the window loses the partition's metadata permanently, and any manifest listing in the window (reopen / recovery on another node) sees NotFound and takes the clear-local-state path.

Retry the promote upload a few times and, if it still fails, return the error from GetManifest so the triggering request fails visibly. Re-entry is safe: the promote path re-downloads the still-present T1 object and the rename idempotently overwrites the byte-identical local T2 copy before retrying the upload.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest handling when the selected term differs from the current process term.
  * Added bounded retry behavior for uploading the promoted local manifest to cloud, with early exit on success or insufficient storage and clearer failure reporting after repeated attempts.
* **Tests**
  * Enhanced concurrency testing by using timed queue waits and periodic progress/heartbeat logging, improving visibility and stability during long runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->