### PR TITLE
fix(cloud): reopen paths must not delete the partition's cloud manifest

### DIFF
--- a/include/async_io_manager.h
+++ b/include/async_io_manager.h
@@ -406,10 +406,25 @@ public:
     /**
      * @brief Drop a partition's manifest — delete it from local disk (and cloud
      *        storage in cloud mode). This does NOT check HasOtherFile, because
-     *        it is called from Drop / Reopen-clean paths where data files are
-     *        expected to still be present and will be cleaned by GC later.
+     *        it is called from the Drop path where data files are expected to
+     *        still be present and will be cleaned by GC later. Only the
+     *        partition owner's drop path may use this; reopen paths must use
+     *        DropLocalManifest.
      */
     virtual KvError DropManifest(const TableIdent &tbl_id) = 0;
+
+    /**
+     * @brief Drop only the LOCAL manifest state for @p tbl_id (file, caches,
+     *        space accounting) — never remote objects. Reopen and snapshot-
+     *        install paths adopt remote state; they consume the cloud
+     *        manifest and must not delete it, no matter what local cleanup
+     *        they perform. Defaults to DropManifest, which is local-only in
+     *        every backend except CloudStoreMgr (which overrides this).
+     */
+    virtual KvError DropLocalManifest(const TableIdent &tbl_id)
+    {
+        return DropManifest(tbl_id);
+    }
 
     virtual void RegisterDirBusy(const TableIdent &tbl_id)
     {
@@ -1183,6 +1198,7 @@ public:
                               uint64_t term) override;
     KvError AbortWrite(const TableIdent &tbl_id) override;
     KvError DropManifest(const TableIdent &tbl_id) override;
+    KvError DropLocalManifest(const TableIdent &tbl_id) override;
 
     ObjectStore &GetObjectStore()
     {

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -5183,7 +5183,7 @@ KvError IouringMgr::DropManifest(const TableIdent &tbl_id)
     return KvError::NoError;
 }
 
-KvError CloudStoreMgr::DropManifest(const TableIdent &tbl_id)
+KvError CloudStoreMgr::DropLocalManifest(const TableIdent &tbl_id)
 {
     // 1. Delete local manifest file.
     KvError err = IouringMgr::DropManifest(tbl_id);
@@ -5192,10 +5192,9 @@ KvError CloudStoreMgr::DropManifest(const TableIdent &tbl_id)
         return err;
     }
 
+    // 2. Remove from FileCleaner's closed-file tracking.
     const std::string manifest_name =
         BranchManifestFileName(GetActiveBranch(), ProcessTerm());
-
-    // 2. Remove from FileCleaner's closed-file tracking.
     if (DequeClosedFile(FileKey(tbl_id, manifest_name)))
     {
         const size_t manifest_size = options_->manifest_limit;
@@ -5204,7 +5203,23 @@ KvError CloudStoreMgr::DropManifest(const TableIdent &tbl_id)
                                 : 0;
     }
 
-    // 3. Delete the manifest from cloud object storage.
+    return KvError::NoError;
+}
+
+KvError CloudStoreMgr::DropManifest(const TableIdent &tbl_id)
+{
+    KvError err = DropLocalManifest(tbl_id);
+    if (err != KvError::NoError)
+    {
+        return err;
+    }
+
+    // Delete the manifest from cloud object storage. Only the partition
+    // owner's Drop path may reach this; reopen / snapshot-install paths go
+    // through DropLocalManifest and must never delete the cloud object they
+    // are adopting state from.
+    const std::string manifest_name =
+        BranchManifestFileName(GetActiveBranch(), ProcessTerm());
     std::string remote_path = tbl_id.ToString() + "/" + manifest_name;
     KvTask *current_task = ThdTask();
     ObjectStore::DeleteTask delete_task(remote_path);

--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -551,7 +551,11 @@ KvError PageManager::InstallExternalSnapshot(const TableIdent &tbl_ident,
                       << "table " << tbl_ident << ", tag " << reopen_tag;
 
             // Delete any stale local manifest and clear in-memory state.
-            KvError drop_err = IoMgr()->DropManifest(tbl_ident);
+            // Local cleanup only: this path adopts remote state and must
+            // never delete remote objects — a spurious NotFound here (e.g.
+            // a lookup bug or transient listing gap) must not destroy the
+            // partition's cloud manifest.
+            KvError drop_err = IoMgr()->DropLocalManifest(tbl_ident);
             if (drop_err != KvError::NoError)
             {
                 LOG(WARNING) << "InstallExternalSnapshot DropManifest failed "

--- a/src/tasks/reopen_task.cpp
+++ b/src/tasks/reopen_task.cpp
@@ -67,12 +67,14 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
     {
         // Remote partition no longer exists: delete local manifest and
         // clear in-memory state instead of writing an empty snapshot.
-        err = shard->IoManager()->DropManifest(tbl_id);
+        // Local cleanup only — reopen adopts remote state and must never
+        // delete remote objects.
+        err = shard->IoManager()->DropLocalManifest(tbl_id);
         if (err != KvError::NoError)
         {
-            LOG(ERROR) << "Reopen " << tbl_id << " DropManifest failed, tag "
-                       << request->Tag() << ", error "
-                       << static_cast<uint32_t>(err);
+            LOG(ERROR) << "Reopen " << tbl_id
+                       << " DropLocalManifest failed, tag " << request->Tag()
+                       << ", error " << static_cast<uint32_t>(err);
             return err;
         }
         RootMetaMgr *root_meta_mgr = shard->IndexManager()->RootMetaManager();


### PR DESCRIPTION
Reopen and snapshot-install adopt remote state: they read the cloud manifest and reconcile local state to it. But their local-cleanup branches called DropManifest, whose CloudStoreMgr override also deletes the manifest_<branch>_<term> object from cloud storage. Any path that reaches those branches with a spurious NotFound therefore destroys the partition's live cloud manifest — and reports success:

- InstallExternalSnapshot treats NotFound/ResourceMissing from RefreshManifest as "remote partition no longer exists" and clears state. The archive-tag lookup builds only archive_<branch>_<process_term>_<tag>, and archives keep the term of the process that created them, so after any failover every pre-existing tag — including every tag GlobalListArchiveTags returns — resolves to NotFound. Reopening to such a tag (or a mistyped one) deleted the live cloud manifest, cleared local state, returned NoError, and left the next cloud GC free to collect every data file the manifest referenced: restore-to-tag silently became drop-partition.
- ReopenTask's clear-local-state branch (Clean reopen / standby rsync NotFound) had the same exposure in cloud mode.

Split the operation: DropLocalManifest removes only local state (file unlink; in CloudStoreMgr also the closed-file tracking entry and its local-space accounting) and is what reopen paths now call. DropManifest keeps the owner-drop semantics (local cleanup + cloud object deletion) and remains the Drop path's call. StandbyStoreMgr/MemStoreMgr need no override: their DropManifest is already local-only, which the default DropLocalManifest forwards to.

The term-brittle archive lookup itself is fixed separately; this change guarantees that even a wrong or unresolvable tag can no longer destroy remote state.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery flows so local cleanup no longer removes remote cloud objects.
  * When a manifest is missing during snapshot install or reopen, the system now clears only local state and preserves remote data.
  * Manifest cleanup now more carefully updates local tracking and space accounting before proceeding with broader removal steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->