### PR TITLE
fix(gc): local file GC must retain live segment files

### DIFF
--- a/src/tasks/write_task.cpp
+++ b/src/tasks/write_task.cpp
@@ -1021,10 +1021,16 @@ KvError WriteTask::TriggerLocalFileGC() const
         tbl_ident_, retained_files, snapshot_array, /*is_segment=*/false);
     CHECK_KV_ERR(build_err);
 
-    // Local GC only runs against data files in this path; segment-file GC is
-    // handled by TriggerFileGC. Pass an empty retained-segment set so the
-    // local GC pass treats segment files as out-of-scope.
+    // Build retained_segment_files from the live segment snapshots, same as
+    // TriggerFileGC: ExecuteLocalGC deletes unreferenced segment files too.
     RetainedFiles retained_segment_files;
+    std::vector<MappingSnapshot::Ref> seg_snapshot_array;
+    build_err = BuildRetainedFiles(tbl_ident_,
+                                   retained_segment_files,
+                                   seg_snapshot_array,
+                                   /*is_segment=*/true);
+    CHECK_KV_ERR(build_err);
+
     IouringMgr *io_mgr = static_cast<IouringMgr *>(shard->IoManager());
     KvError gc_err = FileGarbageCollector::ExecuteLocalGC(
         tbl_ident_, retained_files, retained_segment_files, io_mgr);

--- a/tests/large_value_gc.cpp
+++ b/tests/large_value_gc.cpp
@@ -376,3 +376,82 @@ TEST_CASE(
     store->Stop();
     CleanupStore(opts);
 }
+
+// ---------------------------------------------------------------------------
+// A BatchWrite that slips between a Drop and its queued LocalGc (they share
+// the partition's FIFO write queue) re-creates the partition; the LocalGc
+// must then retain the re-created partition's live sealed segment files.
+// If the g2 write loses the enqueue race the test passes vacuously — it can
+// never fail spuriously.
+// ---------------------------------------------------------------------------
+TEST_CASE("drop-and-recreate keeps the new partition's segment files",
+          "[large-value-gc][pinned]")
+{
+    PinnedHarness h;
+    eloqstore::KvOptions opts = MakePinnedOpts(h);
+    eloqstore::EloqStore *store = InitStore(opts);
+
+    eloqstore::TableIdent tbl{"lvgc_drop_recreate", 0};
+    const size_t seg = h.SegmentSize();
+
+    // Generation 1: sealed segment files for the Drop to collect.
+    {
+        std::vector<PinnedBatchEntry> entries;
+        entries.push_back(
+            {"g1_a", h.AllocateSegmentAligned(seg * 2), 0x2010, "m1a"});
+        entries.push_back(
+            {"g1_b", h.AllocateSegmentAligned(seg * 2), 0x2020, "m1b"});
+        WritePinnedBatch(store, tbl, std::move(entries), /*ts=*/1);
+    }
+
+    // Generation 2 spans more than segments_per_file (8) segments so one of
+    // its files is sealed (past the in-flight tail guard) when LocalGc runs.
+    // Prepare everything before submitting the Drop: the g2 enqueue must
+    // land while the Drop is still executing.
+    auto g2_a = h.AllocateSegmentAligned(seg * 4);
+    auto g2_b = h.AllocateSegmentAligned(seg * 5);
+    FillDeterministic(g2_a.first, g2_a.second, 0x3010);
+    FillDeterministic(g2_b.first, g2_b.second, 0x3020);
+    eloqstore::BatchWriteRequest g2_req;
+    {
+        std::vector<eloqstore::WriteDataEntry> entries;
+        entries.emplace_back(
+            std::string("g2_a"),
+            std::string("m2a"),
+            std::make_pair(static_cast<const char *>(g2_a.first), g2_a.second),
+            /*ts=*/2,
+            eloqstore::WriteOp::Upsert);
+        entries.emplace_back(
+            std::string("g2_b"),
+            std::string("m2b"),
+            std::make_pair(static_cast<const char *>(g2_b.first), g2_b.second),
+            /*ts=*/2,
+            eloqstore::WriteOp::Upsert);
+        std::sort(entries.begin(), entries.end());
+        g2_req.SetArgs(tbl, std::move(entries));
+    }
+
+    // Drop the partition asynchronously and enqueue generation 2 right
+    // behind it: the per-partition FIFO becomes [Drop, BatchWrite(g2),
+    // LocalGc].
+    eloqstore::DropRequest drop_req;
+    drop_req.SetArgs(tbl);
+    REQUIRE(store->ExecAsyn(&drop_req));
+    store->ExecSync(&g2_req);
+    REQUIRE(g2_req.Error() == eloqstore::KvError::NoError);
+
+    drop_req.Wait();
+    REQUIRE(drop_req.Error() == eloqstore::KvError::NoError);
+
+    // Let the queued LocalGc run against the re-created partition.
+    WaitForGc();
+
+    // The re-created partition's values and their segment files survive.
+    SegmentFileInfo after = InspectSegmentFiles(opts, tbl);
+    REQUIRE(after.any);
+    ReadAndVerifyPinned(store, h, tbl, "g2_a", seg * 4, 0x3010, "m2a");
+    ReadAndVerifyPinned(store, h, tbl, "g2_b", seg * 5, 0x3020, "m2b");
+
+    store->Stop();
+    CleanupStore(opts);
+}


### PR DESCRIPTION
TriggerLocalFileGC built the retained set only for data files and passed an empty retained-segment set to ExecuteLocalGC, which deletes unreferenced segment files all the same. TriggerFileGC builds both sets; the segment call was missed on this path.

The empty set destroys real data through a routine interleaving: Drop enqueues its LocalGcRequest at the tail of the partition's FIFO write queue while executing, so a BatchWrite submitted during the Drop runs before that LocalGc and re-creates the partition. When the LocalGc then runs, the manifest-replay fallback is skipped (a live in-memory RootMeta exists, and the skip assumes the caller derived retention from memory) and the in-flight guard covers only the unflushed tail file — so the re-created partition's sealed segment files, holding just-committed large values, are unlinked. Local mode loses acknowledged data permanently; cloud/standby lose the local cache copy.

Build the retained-segment set from the live segment snapshots, same as TriggerFileGC. For a partition that stays dropped BuildRetainedFiles returns an empty set and every file is still collected.

The regression test drops and re-creates a partition back-to-back (pre-built request so the write enqueues while the Drop executes) with enough segments that one segment file is sealed past the tail guard; without the fix its large values fail to read back after the queued LocalGc runs (reproduced 3/3), with it they verify byte-for-byte.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local garbage collection so segment files that are still in use are correctly preserved during cleanup.
  * Fixed an issue where a dropped and recreated partition could lose retained segment files, ensuring newly written values remain available after GC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->