### PR TITLE
fix(storage): SeekFloor must restore the floor entry's large_value_ and expire_ts_

### DIFF
--- a/src/storage/data_page.cpp
+++ b/src/storage/data_page.cpp
@@ -249,9 +249,11 @@ bool DataPageIter::SeekFloor(std::string_view search_key)
     std::string key;
     std::string_view value = {};
     bool overflow = false;
+    bool large_value = false;
     compression::CompressionType compression_kind =
         compression::CompressionType::None;
     uint64_t timestamp = 0;
+    uint64_t expire_ts = 0;
 
     assert(ceil_point <= restart_num_);
     uint16_t limit =
@@ -269,14 +271,21 @@ bool DataPageIter::SeekFloor(std::string_view search_key)
         key = Key();
         value = Value();
         overflow = IsOverflow();
+        large_value = IsLargeValue();
         timestamp = Timestamp();
+        expire_ts = ExpireTs();
         compression_kind = compression_type_;
     }
+    // Restore every field to the floor entry: the loop's last ParseNextKey
+    // parsed the overshoot entry, so any field not snapshotted here would
+    // wrongly carry the overshoot's value.
     curr_offset_ = last_offset;
     key_ = std::move(key);
     value_ = value;
     overflow_ = overflow;
+    large_value_ = large_value;
     timestamp_ = timestamp;
+    expire_ts_ = expire_ts;
     compression_type_ = compression_kind;
     return true;
 }

--- a/tests/large_value_concurrency.cpp
+++ b/tests/large_value_concurrency.cpp
@@ -978,3 +978,75 @@ TEST_CASE(
     store->Stop();
     CleanupStore(opts);
 }
+
+// ---------------------------------------------------------------------------
+// SeekFloor snapshots the floor entry's key/value/timestamp but not its
+// large_value_ flag, so the floor result inherits that flag from the
+// OVERSHOOT entry (the first key greater than the search key). A Floor
+// landing on a large (segment-backed) value whose in-region successor is a
+// small value then reports IsLargeValue()==false and skips loading the
+// segment payload — the floor returns without its large value.
+// ---------------------------------------------------------------------------
+TEST_CASE("floor of a large value loads it, not the next entry's flag",
+          "[large-value][floor]")
+{
+    Harness h(/*num_shards=*/1);
+    eloqstore::KvOptions opts = MakeOpts(h);
+    opts.data_page_restart_interval = 2;  // few keys span multiple regions
+    eloqstore::EloqStore *store = InitStore(opts);
+    h.BindStore(store);
+
+    eloqstore::TableIdent tbl{"lvc_floor", 0};
+    const size_t large_size = h.SegmentSize() * 2 + 7;  // 3 segments
+    const uint64_t seed = 0xC3C3C3C3ULL;
+
+    // Eight keys in one data page. key02 is a large (segment) value; the rest
+    // are small. Restart interval 2 puts restart points on key00/02/04/06, so
+    // the floor (key02) and its overshoot (key03, a small non-restart entry)
+    // share a restart region — the buggy SeekFloor branch. (When the overshoot
+    // is itself a restart point the scan stops before parsing it, so it must
+    // be a mid-region entry to leak.)
+    eloqstore::BatchWriteRequest wreq;
+    std::vector<eloqstore::WriteDataEntry> entries;
+    for (int i = 0; i < 8; ++i)
+    {
+        std::string key = "key0" + std::to_string(i);
+        if (i == 2)
+        {
+            entries.emplace_back(key,
+                                 h.MakeLargeValue(0, large_size, seed),
+                                 /*ts=*/10,
+                                 eloqstore::WriteOp::Upsert);
+        }
+        else
+        {
+            entries.emplace_back(key,
+                                 "small_" + key,
+                                 /*ts=*/10,
+                                 eloqstore::WriteOp::Upsert);
+        }
+    }
+    wreq.SetArgs(tbl, std::move(entries));
+    store->ExecSync(&wreq);
+    REQUIRE(wreq.Error() == eloqstore::KvError::NoError);
+    h.RecycleBatch(wreq, 0);
+
+    // "key02z" floors to key02 (the large value); the overshoot is key03
+    // (small). The floor must load key02's large value, not inherit key03's
+    // "not a large value" flag and skip it.
+    eloqstore::FloorRequest freq;
+    freq.SetArgs(tbl, std::string("key02z"));
+    store->ExecSync(&freq);
+    REQUIRE(freq.Error() == eloqstore::KvError::NoError);
+    REQUIRE(freq.floor_key_ == "key02");
+    REQUIRE(freq.large_value_.Size() == large_size);
+    REQUIRE(h.VerifyLargeValue(freq.large_value_, large_size, seed));
+
+    if (!freq.large_value_.Fragments().empty())
+    {
+        freq.large_value_.Recycle(h.Memory(0), h.RegBase(0));
+    }
+    store->Stop();
+    h.AssertPoolRestored();
+    CleanupStore(opts);
+}

--- a/tests/scan.cpp
+++ b/tests/scan.cpp
@@ -1,7 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common.h"
 #include "test_utils.h"
@@ -127,4 +131,56 @@ TEST_CASE("read floor", "[read]")
     {
         verify.Floor(Key(i));
     }
+}
+
+// SeekFloor's linear-scan branch snapshots the floor entry's key/value/
+// timestamp but not its large_value_/expire_ts_ flags, so the floor result
+// keeps those two fields from the OVERSHOOT entry (the first key greater than
+// the search key). A Floor query landing strictly between two keys within a
+// restart region then reports the neighbor's expire timestamp.
+TEST_CASE("floor reports its own expire_ts, not the next entry's",
+          "[scan][floor]")
+{
+    eloqstore::KvOptions opts = default_opts;
+    // Small restart interval so few keys span multiple restart regions and
+    // the floor lands inside one (the buggy linear-scan branch).
+    opts.data_page_restart_interval = 2;
+
+    eloqstore::EloqStore *store = InitStore(opts);
+    eloqstore::TableIdent tbl{"floor_expire", 0};
+
+    constexpr uint64_t kFuture = 9'000'000'000'000ULL;  // far-future expire ms
+    // Eight keys; every key never expires except "key03", the overshoot for a
+    // "key02z" floor query. With restart interval 2 the restart points fall on
+    // key00/key02/key04/key06, so the floor (key02) and the overshoot (key03,
+    // a non-restart entry the linear scan parses before breaking) lie in the
+    // same restart region — exactly the buggy branch. (When the overshoot is
+    // itself a restart point the scan stops before parsing it, so it must be a
+    // mid-region entry to leak.)
+    std::vector<eloqstore::WriteDataEntry> entries;
+    for (int i = 0; i < 8; ++i)
+    {
+        char key[8];
+        std::snprintf(key, sizeof(key), "key%02d", i);
+        uint64_t expire = (i == 3) ? kFuture : 0;
+        entries.emplace_back(std::string(key),
+                             std::string("v") + key,
+                             /*ts=*/10,
+                             eloqstore::WriteOp::Upsert,
+                             expire);
+    }
+    eloqstore::BatchWriteRequest wreq;
+    wreq.SetArgs(tbl, std::move(entries));
+    store->ExecSync(&wreq);
+    REQUIRE(wreq.Error() == eloqstore::KvError::NoError);
+
+    // "key02z" floors to key02 (never-expires); the overshoot is key03
+    // (expire=kFuture). The reported expire_ts_ must be key02's, i.e. 0.
+    eloqstore::FloorRequest freq;
+    freq.SetArgs(tbl, std::string("key02z"));
+    store->ExecSync(&freq);
+    REQUIRE(freq.Error() == eloqstore::KvError::NoError);
+    REQUIRE(freq.floor_key_ == "key02");
+    REQUIRE(freq.value_ == "vkey02");
+    REQUIRE(freq.expire_ts_ == 0);
 }


### PR DESCRIPTION
SeekFloor's linear-scan branch snapshots the floor entry's key/value/overflow/timestamp/compression into locals and restores them after the loop, but omitted large_value_ and expire_ts_. The loop's last ParseNextKey parses the OVERSHOOT entry (the first key greater than the search key, which triggers the break), so those two unrestored fields keep the overshoot entry's values. A Floor landing strictly between two keys within a restart region then returns the correct floor key/value but the neighbor's large-value flag and expire timestamp.

Impact on the public Floor API (read_task.cpp Floor):
- expire_ts is returned verbatim to the caller (the engine does not TTL-filter at read/floor/scan time), so the floor entry is reported with the neighbor's expiry — a never-expiring key can look expired (data vanishes) or vice versa.
- iter.IsLargeValue() decides whether the segment payload is loaded, so a large-value floor whose neighbor is small skips the load and returns an empty large value; the reverse tries to read a small inline value as segment pointers.

Snapshot and restore both fields alongside the others. Read (Seek) is unaffected: it returns positioned exactly on the matching entry and never backs up, so its fields are always self-consistent.

Two regression tests, each failing before the fix:
- tests/scan.cpp: a Floor between two keys reports the neighbor's expire_ts (9e12 instead of 0).
- tests/large_value_concurrency.cpp: a Floor onto a large value whose in-region successor is small returns an empty large value (Size 0). Both require the overshoot to be a mid-region (non-restart) entry — the scan stops before parsing a boundary restart point.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floor-key lookups so the returned entry keeps its own metadata after scanning past the target.
  * Large values now return the correct value flag and content for floor results.
  * Expiration timestamps are now reported from the matched entry, not the next entry encountered during the scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->