### PR TITLE
fix: read callback_ before publishing done_ in SetDone (UAF)

### DIFF
--- a/src/eloq_store.cpp
+++ b/src/eloq_store.cpp
@@ -2727,14 +2727,17 @@ void KvRequest::SetDone(KvError err)
         callback(this);
     }
 #else
-    done_.store(true, std::memory_order_release);
+    // Publishing done_ lets a sync Wait()er return and free this request, so
+    // read callback_ before the store, not after.
     if (callback_)
     {
         auto callback = std::move(callback_);
+        done_.store(true, std::memory_order_release);
         callback(this);
     }
     else
     {
+        done_.store(true, std::memory_order_release);
         done_.notify_one();
     }
 #endif


### PR DESCRIPTION
In the non-module build SetDone stored done_ (release) and only then read callback_ to pick the sync-vs-async branch. Publishing done_ lets a sync Wait()er return, and ExecSync requests are typically caller stack/owned, so the caller can destroy the request between the store and the callback_ read — SetDone then dereferences a freed member (and calls notify_one on a freed atomic).

Sync (no callback, waits on done_) and async (callback set, never waits — Wait() CHECKs callback_ == nullptr) are mutually exclusive, so moving the callback_ read/move ahead of the store is safe: no waiter can have woken yet. After the store SetDone touches only the atomic's own notify, never a data member. Mirrors the module-mode path, which already decides the branch under the mutex before signalling.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion handling to ensure callbacks are invoked reliably before requests are marked finished.
  * Strengthened request notification flow to reduce the chance of missed or out-of-order completion updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->