### PR TITLE
fix: empty BatchWriteRequest wedged the partition write queue

### DIFF
--- a/include/tasks/batch_write_task.h
+++ b/include/tasks/batch_write_task.h
@@ -23,7 +23,7 @@ public:
     void Reset(const TableIdent &tbl_id) override;
     void Abort() override;
 
-    bool SetBatch(std::span<WriteDataEntry> entries);
+    void SetBatch(std::span<WriteDataEntry> entries);
     KvError Apply();
 
     KvError Truncate(std::string_view trunc_pos);

--- a/src/storage/shard.cpp
+++ b/src/storage/shard.cpp
@@ -747,14 +747,11 @@ bool Shard::ProcessReq(KvRequest *req)
         }
         auto write_req = static_cast<BatchWriteRequest *>(req);
         task->Reset(req->TableId());
-        if (!write_req->batch_.empty())
-        {
-            if (!task->SetBatch(write_req->batch_))
-            {
-                return false;
-            }
-            StartTask(task, req, [task]() { return task->Apply(); });
-        }
+        task->SetBatch(write_req->batch_);
+        // An empty batch runs as a no-op Apply and completes normally.
+        // Skipping StartTask here instead would leave running_ set and the
+        // request never completed, wedging the partition's write queue.
+        StartTask(task, req, [task]() { return task->Apply(); });
         return true;
     }
     case RequestType::Truncate:

--- a/src/tasks/batch_write_task.cpp
+++ b/src/tasks/batch_write_task.cpp
@@ -198,7 +198,7 @@ void BatchWriteTask::Reset(const TableIdent &tbl_id)
     }
 }
 
-bool BatchWriteTask::SetBatch(std::span<WriteDataEntry> entries)
+void BatchWriteTask::SetBatch(std::span<WriteDataEntry> entries)
 {
 #ifndef NDEBUG
     const Comparator *cmp = Comp();
@@ -226,7 +226,6 @@ bool BatchWriteTask::SetBatch(std::span<WriteDataEntry> entries)
 #endif
 
     data_batch_ = entries;
-    return true;
 }
 
 void BatchWriteTask::Abort()

--- a/tests/batch_write.cpp
+++ b/tests/batch_write.cpp
@@ -414,3 +414,36 @@ TEST_CASE("batch write task pool cleaned after abort", "[batch_write]")
 
     REQUIRE(saw_abort);
 }
+
+// An empty BatchWriteRequest is a no-op. It must complete (not hang) and must
+// not wedge the partition's write queue: dispatching an empty batch used to
+// skip StartTask while leaving the per-table queue running_, so the request
+// never completed and every later write to the same partition stalled behind
+// it forever.
+TEST_CASE("empty batch write completes and leaves the partition writable",
+          "[batch_write]")
+{
+    eloqstore::EloqStore *store = InitStore(default_opts);
+    eloqstore::TableIdent tbl_id("empty_batch", 0);
+
+    // The empty batch itself must return (before the fix ExecSync hung here).
+    eloqstore::BatchWriteRequest empty_req;
+    empty_req.SetArgs(tbl_id, std::vector<eloqstore::WriteDataEntry>{});
+    store->ExecSync(&empty_req);
+    REQUIRE(empty_req.Error() == eloqstore::KvError::NoError);
+
+    // A subsequent write to the same partition must still complete (the queue
+    // was not left wedged) and be readable back.
+    eloqstore::BatchWriteRequest next_req;
+    std::vector<eloqstore::WriteDataEntry> entries;
+    entries.emplace_back("k", "v", 1, eloqstore::WriteOp::Upsert);
+    next_req.SetArgs(tbl_id, std::move(entries));
+    store->ExecSync(&next_req);
+    REQUIRE(next_req.Error() == eloqstore::KvError::NoError);
+
+    eloqstore::ReadRequest read;
+    read.SetArgs(tbl_id, "k");
+    store->ExecSync(&read);
+    REQUIRE(read.Error() == eloqstore::KvError::NoError);
+    REQUIRE(read.value_ == "v");
+}


### PR DESCRIPTION
ProcessReq's BatchWrite case skipped StartTask when batch_ was empty but still returned true (the "task started" signal). Nothing then cleared the per-table queue's running_ flag or completed the request: the empty batch's ExecSync hung forever and every later write to the same partition stalled behind the stuck running_.

An empty batch is a valid no-op input (e.g. all entries filtered out upstream). Let it run through Apply like any other batch — Apply's per-entry loop simply does nothing for an empty batch and completes via the normal task path (running_ cleared, request SetDone, next write dispatched). No special-casing on the request-receive path.

Also drop SetBatch's bool return: every validation is debug-only assert, so it always returned true; the dead 'if (!SetBatch) return false' branch in ProcessReq is removed with it.

Regression test: an empty batch's ExecSync hangs on unfixed code (30s timeout kill) and returns immediately with the fix, and a subsequent write to the same partition still completes and reads back.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`
