### PR TITLE
fix: reopen clear-local-state resets RootMeta via COW, not in place

### DIFF
--- a/include/storage/page_manager.h
+++ b/include/storage/page_manager.h
@@ -67,8 +67,10 @@ public:
                                     CowRootMeta &cow_meta,
                                     std::string_view reopen_tag,
                                     bool &cleared_local_state);
-    KvError InstallEmptySnapshot(const TableIdent &tbl_ident,
-                                 CowRootMeta &cow_meta);
+    // Reset the partition to an empty root through the COW UpdateRoot path
+    // (safe against concurrent readers). The caller must have already removed
+    // the manifest; no manifest is written.
+    void InstallEmptyRoot(const TableIdent &tbl_ident, CowRootMeta &cow_meta);
 
     void FreeMappingSnapshot(MappingSnapshot *mapping);
 

--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -424,49 +424,34 @@ void PageManager::UpdateRoot(const TableIdent &tbl_ident, CowRootMeta new_meta)
     root_meta_mgr_.EvictIfNeeded();
 }
 
-KvError PageManager::InstallEmptySnapshot(const TableIdent &tbl_ident,
-                                          CowRootMeta &cow_meta)
+void PageManager::InstallEmptyRoot(const TableIdent &tbl_ident,
+                                   CowRootMeta &cow_meta)
 {
+    // Reset the partition to an empty root through the COW UpdateRoot path so
+    // it is safe against concurrent readers: a fresh empty mapper replaces the
+    // old one (old snapshot chained + ref-counted, so an in-flight read keeps
+    // a valid mapping and compression until it releases), rather than nulling
+    // RootMeta fields in place. The caller has already removed the manifest,
+    // so no manifest is written (partition absent, not empty-but-present).
     auto [entry, inserted] = RootMetaManager()->GetOrCreate(tbl_ident);
     static_cast<void>(inserted);
     RootMeta &meta = entry->meta_;
-    auto mapper = std::make_unique<PageMapper>(this, &entry->tbl_id_);
 
     cow_meta = CowRootMeta();
     cow_meta.root_id_ = MaxPageId;
     cow_meta.ttl_root_id_ = MaxPageId;
-    cow_meta.mapper_ = std::move(mapper);
+    cow_meta.mapper_ = std::make_unique<PageMapper>(this, &entry->tbl_id_);
     cow_meta.next_expire_ts_ = 0;
     cow_meta.compression_ = std::make_shared<compression::DictCompression>();
+    cow_meta.manifest_size_ = 0;
+    cow_meta.first_unflushed_fp_id_ =
+        cow_meta.mapper_->FilePgAllocator()->MaxFilePageId();
 
-    BranchManifestMetadata branch_metadata;
-    branch_metadata.branch_name = IoMgr()->GetActiveBranch();
-    branch_metadata.term = IoMgr()->ProcessTerm();
-    branch_metadata.file_ranges = {};
-
-    ManifestBuilder manifest_builder;
-    FilePageId max_fp_id = cow_meta.mapper_->FilePgAllocator()->MaxFilePageId();
-    std::string_view snapshot =
-        manifest_builder.Snapshot(cow_meta.root_id_,
-                                  cow_meta.ttl_root_id_,
-                                  cow_meta.mapper_->GetMapping(),
-                                  max_fp_id,
-                                  {},
-                                  branch_metadata);
-    // Use the base local manifest rewrite path here. The cloud override also
-    // uploads the manifest, but an empty snapshot should only replace local
-    // state for reopen/cleanup.
-    auto *io_mgr = static_cast<IouringMgr *>(IoMgr());
-    KvError err = io_mgr->IouringMgr::SwitchManifest(tbl_ident, snapshot);
-    CHECK_KV_ERR(err);
     auto it = meta.mapping_snapshots_.insert(cow_meta.mapper_->GetMapping());
     CHECK(it.second);
-    cow_meta.manifest_size_ = snapshot.size();
-    cow_meta.first_unflushed_fp_id_ = max_fp_id;
 
     UpdateRoot(tbl_ident, std::move(cow_meta));
     IoMgr()->SetBranchFileMapping(entry->tbl_id_, {});
-    return KvError::NoError;
 }
 
 KvError PageManager::InstallExternalSnapshot(const TableIdent &tbl_ident,

--- a/src/tasks/read_task.cpp
+++ b/src/tasks/read_task.cpp
@@ -43,6 +43,13 @@ KvError LocateAndProcess(const TableIdent &tbl_id,
         return KvError::NotFound;
     }
     auto mapping = meta->mapper_->GetMappingSnapshot();
+    // Capture the compression dictionary alongside the mapping snapshot, as a
+    // shared_ptr the read owns for its whole duration. A concurrent reopen
+    // (clear or install-new-snapshot) replaces meta->compression_ with a
+    // different object during our IO yields; without holding our own
+    // reference the read would decode this snapshot's data with the wrong
+    // (or freed) dictionary.
+    auto compression = meta->compression_;
     MappingSnapshot::Ref seg_mapping_ref{nullptr};
     if (meta->segment_mapper_ != nullptr)
     {
@@ -64,7 +71,7 @@ KvError LocateAndProcess(const TableIdent &tbl_id,
     }
 
     KvError fetch_err =
-        handler(meta, mapping.Get(), seg_mapping_ref.Get(), iter);
+        handler(compression.get(), mapping.Get(), seg_mapping_ref.Get(), iter);
     if (fetch_err != KvError::NoError)
     {
         return fetch_err;
@@ -88,7 +95,7 @@ KvError ReadTask::Read(const TableIdent &tbl_id,
         search_key,
         timestamp,
         expire_ts,
-        [&](RootMeta *meta,
+        [&](compression::DictCompression *compression,
             MappingSnapshot *mapping,
             MappingSnapshot *seg_mapping,
             DataPageIter &iter) -> KvError
@@ -97,7 +104,7 @@ KvError ReadTask::Read(const TableIdent &tbl_id,
                                                  mapping,
                                                  iter,
                                                  value,
-                                                 meta->compression_.get(),
+                                                 compression,
                                                  extract_metadata);
             if (err != KvError::NoError)
             {
@@ -131,13 +138,13 @@ KvError ReadTask::Read(const TableIdent &tbl_id,
         search_key,
         timestamp,
         expire_ts,
-        [&](RootMeta *meta,
+        [&](compression::DictCompression *compression,
             MappingSnapshot *mapping,
             MappingSnapshot *seg_mapping,
             DataPageIter &iter) -> KvError
         {
             KvError err = ResolveValueOrMetadata(
-                tbl_id, mapping, iter, value, meta->compression_.get());
+                tbl_id, mapping, iter, value, compression);
             if (err != KvError::NoError)
             {
                 return err;
@@ -167,7 +174,7 @@ KvError ReadTask::Read(const TableIdent &tbl_id,
         search_key,
         timestamp,
         expire_ts,
-        [&](RootMeta * /*meta*/,
+        [&](compression::DictCompression * /*compression*/,
             MappingSnapshot * /*mapping*/,
             MappingSnapshot *seg_mapping,
             DataPageIter &iter) -> KvError
@@ -203,6 +210,10 @@ KvError ReadTask::Floor(const TableIdent &tbl_id,
         return KvError::NotFound;
     }
     auto mapping = meta->mapper_->GetMappingSnapshot();
+    // See Get: own a reference to the compression dictionary for the whole
+    // read so a concurrent reopen replacing meta->compression_ cannot make us
+    // decode with the wrong dictionary.
+    auto compression = meta->compression_;
     MappingSnapshot::Ref seg_mapping_ref{nullptr};
     if (meta->segment_mapper_ != nullptr)
     {
@@ -233,7 +244,7 @@ KvError ReadTask::Floor(const TableIdent &tbl_id,
     }
     floor_key = iter.Key();
     KvError fetch_err = ResolveValueOrMetadata(
-        tbl_id, mapping.Get(), iter, value, meta->compression_.get());
+        tbl_id, mapping.Get(), iter, value, compression.get());
     CHECK_KV_ERR(fetch_err);
     if (iter.IsLargeValue() && large_value != nullptr)
     {

--- a/src/tasks/reopen_task.cpp
+++ b/src/tasks/reopen_task.cpp
@@ -65,8 +65,14 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
                              sync_err == KvError::ResourceMissing;
     if (clear_local_state)
     {
-        // Remote partition no longer exists: delete local manifest and
-        // clear in-memory state instead of writing an empty snapshot.
+        // Remote partition no longer exists: delete the local manifest and
+        // reset in-memory state to an empty root. Reopen is NOT serialized
+        // against reads, so the reset goes through the COW UpdateRoot path
+        // (InstallEmptyRoot) rather than mutating RootMeta in place — an
+        // in-place reset would null mapper_/compression_ that a concurrent
+        // read still dereferences after an IO yield. write_manifest is false
+        // because DropManifest already removed it (partition absent, not
+        // empty-but-present).
         err = shard->IoManager()->DropManifest(tbl_id);
         if (err != KvError::NoError)
         {
@@ -75,23 +81,7 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
                        << static_cast<uint32_t>(err);
             return err;
         }
-        RootMetaMgr *root_meta_mgr = shard->IndexManager()->RootMetaManager();
-        auto *entry = root_meta_mgr->Find(tbl_id);
-        if (entry != nullptr)
-        {
-            RootMeta &meta = entry->meta_;
-            meta.root_id_ = MaxPageId;
-            meta.ttl_root_id_ = MaxPageId;
-            meta.manifest_size_ = 0;
-            meta.next_expire_ts_ = 0;
-            meta.mapper_.reset();
-            meta.mapping_snapshots_.clear();
-            meta.compression_.reset();
-            root_meta_mgr->UpdateBytes(entry, 0);
-        }
-        cow_meta_ = CowRootMeta();
-        cow_meta_.root_id_ = MaxPageId;
-        cow_meta_.ttl_root_id_ = MaxPageId;
+        shard->IndexManager()->InstallEmptyRoot(tbl_id, cow_meta_);
     }
     else
     {


### PR DESCRIPTION
The clear-local-state reopen path (remote partition gone, or Clean reopen) reset the in-memory RootMeta by nulling its fields directly: mapper_.reset(), compression_.reset(), mapping_snapshots_.clear(). Reopen is NOT serialized against reads (auto-reopen is triggered by a read's ResourceMissing; a user GlobalReopen can also run concurrently), so a read that captured this partition's RootMeta and yielded on IO resumes to dereference the now-null fields — meta->compression_ in ResolveValueOrMetadata is a null deref, and when the read's held MappingSnapshot ref finally drops, FreeMappingSnapshot dereferences the null mapper_. Every other root transition (writes, InstallExternalSnapshot) goes through the COW UpdateRoot path, which replaces fields with valid new objects and chains the old snapshot so in-flight readers stay valid; the in-place clear was the lone exception.

Route the clear through the same COW path: install a fresh empty mapper
+ empty compression + root_id=MaxPageId via UpdateRoot. A concurrent read keeps a valid (old, ref-counted) mapping and valid compression; new reads see the empty root. The empty mapper is also the correct end state — leaving the old mapper would keep GC's retained set non-empty so the partition's files never get collected.

Replaces the unused InstallEmptySnapshot (no callers; its manifest- writing branch was dead) with a focused InstallEmptyRoot that only resets in-memory state — the manifest is already removed by DropManifest (partition absent, not empty-but-present).

Note: while an in-flight reader holds the old snapshot, that GC cycle retains the old files until the reader releases — pre-existing correct behavior (don't delete files a reader is still using), not introduced here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when reopening a partition that no longer exists remotely, ensuring local state is reset via a clean empty-root installation path.
  * Empty partitions now initialize with fresh root and compression-related metadata and an empty branch file mapping, reducing stale/inconsistent reads after cleanup.
  * Reads now reuse a consistent compression dictionary reference for the full operation lifetime, improving correctness when resolving values and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->