### PR TITLE
fix(cloud): reopen clear must not delete cloud manifest; reads own their compression dictionary

### DIFF
--- a/include/async_io_manager.h
+++ b/include/async_io_manager.h
@@ -406,10 +406,25 @@ public:
     /**
      * @brief Drop a partition's manifest — delete it from local disk (and cloud
      *        storage in cloud mode). This does NOT check HasOtherFile, because
-     *        it is called from Drop / Reopen-clean paths where data files are
-     *        expected to still be present and will be cleaned by GC later.
+     *        it is called from the Drop path where data files are expected to
+     *        still be present and will be cleaned by GC later. Only the
+     *        partition owner's drop path may use this; reopen paths must use
+     *        DropLocalManifest.
      */
     virtual KvError DropManifest(const TableIdent &tbl_id) = 0;
+
+    /**
+     * @brief Drop only the LOCAL manifest state for @p tbl_id (file, caches,
+     *        space accounting) — never remote objects. Reopen and snapshot-
+     *        install paths adopt remote state; they consume the cloud
+     *        manifest and must not delete it, no matter what local cleanup
+     *        they perform. Defaults to DropManifest, which is local-only in
+     *        every backend except CloudStoreMgr (which overrides this).
+     */
+    virtual KvError DropLocalManifest(const TableIdent &tbl_id)
+    {
+        return DropManifest(tbl_id);
+    }
 
     virtual void RegisterDirBusy(const TableIdent &tbl_id)
     {
@@ -1183,6 +1198,7 @@ public:
                               uint64_t term) override;
     KvError AbortWrite(const TableIdent &tbl_id) override;
     KvError DropManifest(const TableIdent &tbl_id) override;
+    KvError DropLocalManifest(const TableIdent &tbl_id) override;
 
     ObjectStore &GetObjectStore()
     {

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -5202,7 +5202,7 @@ KvError IouringMgr::DropManifest(const TableIdent &tbl_id)
     return KvError::NoError;
 }
 
-KvError CloudStoreMgr::DropManifest(const TableIdent &tbl_id)
+KvError CloudStoreMgr::DropLocalManifest(const TableIdent &tbl_id)
 {
     // 1. Delete local manifest file.
     KvError err = IouringMgr::DropManifest(tbl_id);
@@ -5211,10 +5211,9 @@ KvError CloudStoreMgr::DropManifest(const TableIdent &tbl_id)
         return err;
     }
 
+    // 2. Remove from FileCleaner's closed-file tracking.
     const std::string manifest_name =
         BranchManifestFileName(GetActiveBranch(), ProcessTerm());
-
-    // 2. Remove from FileCleaner's closed-file tracking.
     if (DequeClosedFile(FileKey(tbl_id, manifest_name)))
     {
         const size_t manifest_size = options_->manifest_limit;
@@ -5223,7 +5222,23 @@ KvError CloudStoreMgr::DropManifest(const TableIdent &tbl_id)
                                 : 0;
     }
 
-    // 3. Delete the manifest from cloud object storage.
+    return KvError::NoError;
+}
+
+KvError CloudStoreMgr::DropManifest(const TableIdent &tbl_id)
+{
+    KvError err = DropLocalManifest(tbl_id);
+    if (err != KvError::NoError)
+    {
+        return err;
+    }
+
+    // Delete the manifest from cloud object storage. Only the partition
+    // owner's Drop path may reach this; reopen / snapshot-install paths go
+    // through DropLocalManifest and must never delete the cloud object they
+    // are adopting state from.
+    const std::string manifest_name =
+        BranchManifestFileName(GetActiveBranch(), ProcessTerm());
     std::string remote_path = tbl_id.ToString() + "/" + manifest_name;
     KvTask *current_task = ThdTask();
     ObjectStore::DeleteTask delete_task(remote_path);

--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -551,7 +551,11 @@ KvError PageManager::InstallExternalSnapshot(const TableIdent &tbl_ident,
                       << "table " << tbl_ident << ", tag " << reopen_tag;
 
             // Delete any stale local manifest and clear in-memory state.
-            KvError drop_err = IoMgr()->DropManifest(tbl_ident);
+            // Local cleanup only: this path adopts remote state and must
+            // never delete remote objects — a spurious NotFound here (e.g.
+            // a lookup bug or transient listing gap) must not destroy the
+            // partition's cloud manifest.
+            KvError drop_err = IoMgr()->DropLocalManifest(tbl_ident);
             if (drop_err != KvError::NoError)
             {
                 LOG(WARNING) << "InstallExternalSnapshot DropManifest failed "

--- a/src/tasks/read_task.cpp
+++ b/src/tasks/read_task.cpp
@@ -43,6 +43,13 @@ KvError LocateAndProcess(const TableIdent &tbl_id,
         return KvError::NotFound;
     }
     auto mapping = meta->mapper_->GetMappingSnapshot();
+    // Capture the compression dictionary alongside the mapping snapshot, as a
+    // shared_ptr the read owns for its whole duration. A concurrent reopen
+    // (clear or install-new-snapshot) replaces meta->compression_ with a
+    // different object during our IO yields; without holding our own
+    // reference the read would decode this snapshot's data with the wrong
+    // (or freed) dictionary.
+    auto compression = meta->compression_;
     MappingSnapshot::Ref seg_mapping_ref{nullptr};
     if (meta->segment_mapper_ != nullptr)
     {
@@ -64,7 +71,7 @@ KvError LocateAndProcess(const TableIdent &tbl_id,
     }
 
     KvError fetch_err =
-        handler(meta, mapping.Get(), seg_mapping_ref.Get(), iter);
+        handler(compression.get(), mapping.Get(), seg_mapping_ref.Get(), iter);
     if (fetch_err != KvError::NoError)
     {
         return fetch_err;
@@ -88,17 +95,13 @@ KvError ReadTask::Read(const TableIdent &tbl_id,
         search_key,
         timestamp,
         expire_ts,
-        [&](RootMeta *meta,
+        [&](compression::DictCompression *compression,
             MappingSnapshot *mapping,
             MappingSnapshot *seg_mapping,
             DataPageIter &iter) -> KvError
         {
-            KvError err = ResolveValueOrMetadata(tbl_id,
-                                                 mapping,
-                                                 iter,
-                                                 value,
-                                                 meta->compression_.get(),
-                                                 extract_metadata);
+            KvError err = ResolveValueOrMetadata(
+                tbl_id, mapping, iter, value, compression, extract_metadata);
             if (err != KvError::NoError)
             {
                 return err;
@@ -131,13 +134,13 @@ KvError ReadTask::Read(const TableIdent &tbl_id,
         search_key,
         timestamp,
         expire_ts,
-        [&](RootMeta *meta,
+        [&](compression::DictCompression *compression,
             MappingSnapshot *mapping,
             MappingSnapshot *seg_mapping,
             DataPageIter &iter) -> KvError
         {
             KvError err = ResolveValueOrMetadata(
-                tbl_id, mapping, iter, value, meta->compression_.get());
+                tbl_id, mapping, iter, value, compression);
             if (err != KvError::NoError)
             {
                 return err;
@@ -167,7 +170,7 @@ KvError ReadTask::Read(const TableIdent &tbl_id,
         search_key,
         timestamp,
         expire_ts,
-        [&](RootMeta * /*meta*/,
+        [&](compression::DictCompression * /*compression*/,
             MappingSnapshot * /*mapping*/,
             MappingSnapshot *seg_mapping,
             DataPageIter &iter) -> KvError
@@ -203,6 +206,10 @@ KvError ReadTask::Floor(const TableIdent &tbl_id,
         return KvError::NotFound;
     }
     auto mapping = meta->mapper_->GetMappingSnapshot();
+    // See Get: own a reference to the compression dictionary for the whole
+    // read so a concurrent reopen replacing meta->compression_ cannot make us
+    // decode with the wrong dictionary.
+    auto compression = meta->compression_;
     MappingSnapshot::Ref seg_mapping_ref{nullptr};
     if (meta->segment_mapper_ != nullptr)
     {
@@ -233,7 +240,7 @@ KvError ReadTask::Floor(const TableIdent &tbl_id,
     }
     floor_key = iter.Key();
     KvError fetch_err = ResolveValueOrMetadata(
-        tbl_id, mapping.Get(), iter, value, meta->compression_.get());
+        tbl_id, mapping.Get(), iter, value, compression.get());
     CHECK_KV_ERR(fetch_err);
     if (iter.IsLargeValue() && large_value != nullptr)
     {

--- a/src/tasks/reopen_task.cpp
+++ b/src/tasks/reopen_task.cpp
@@ -67,12 +67,14 @@ KvError ReopenTask::Reopen(const TableIdent &tbl_id)
     {
         // Remote partition no longer exists: delete local manifest and
         // clear in-memory state instead of writing an empty snapshot.
-        err = shard->IoManager()->DropManifest(tbl_id);
+        // Local cleanup only — reopen adopts remote state and must never
+        // delete remote objects.
+        err = shard->IoManager()->DropLocalManifest(tbl_id);
         if (err != KvError::NoError)
         {
-            LOG(ERROR) << "Reopen " << tbl_id << " DropManifest failed, tag "
-                       << request->Tag() << ", error "
-                       << static_cast<uint32_t>(err);
+            LOG(ERROR) << "Reopen " << tbl_id
+                       << " DropLocalManifest failed, tag " << request->Tag()
+                       << ", error " << static_cast<uint32_t>(err);
             return err;
         }
         RootMetaMgr *root_meta_mgr = shard->IndexManager()->RootMetaManager();


### PR DESCRIPTION
Combines two related fixes to the reopen clear-local-state path (supersedes #464 and #470).

## 1. Reopen must not delete the partition's cloud manifest

Reopen adopts remote state — it reads the cloud manifest and reconciles local state to it. But the clear-local-state branch called `DropManifest`, whose `CloudStoreMgr` override also deletes the `manifest_<branch>_<term>` object from cloud storage. Any path reaching that branch with a spurious `NotFound` (e.g. a mistyped/unresolvable archive tag) therefore destroyed the partition's live cloud manifest and reported success.

Split `DropManifest` into `DropLocalManifest` (local file + caches + space accounting, no remote object) and let the reopen/clear path call the local-only variant. Reopen only ever cleans local cache. `StandbyStoreMgr`/`MemStoreMgr` need no override — their `DropManifest` is already local-only.

## 2. Reads own their compression dictionary for the whole read

The clear-local-state reset (remote gone, or `Clean` reopen) nulls the in-memory `RootMeta` fields, including `compression_.reset()`. Reopen is **not** serialized against reads (auto-reopen is triggered by a read's `ResourceMissing`; a user `GlobalReopen` can also run concurrently). The read/floor paths captured the mapping snapshot (ref-counted) before yielding on IO but read `meta->compression_` **live** afterward — so a read that captured this partition's mapping could resume to decode with a null dictionary (crash). `InstallExternalSnapshot` (reopen to a new remote snapshot) has the same shape: it swaps `compression_` for the remote snapshot's dictionary, so a concurrent read would decode with the wrong one.

Fix: capture `meta->compression_` as a `shared_ptr` copy alongside the mapping snapshot (both before any yield) and decode through the captured reference. The read owns its dictionary for its whole duration regardless of a concurrent reopen. Normal writes were already safe (`MakeCowRoot` shares the same dictionary object, appended in place).

### Why the in-place reset stays

`mapper_ == nullptr` is the engine's "partition absent" signal: local GC relies on it to reclaim the files (`SeedActiveBranchGuardFromInMemory` seeds no in-flight guard for a null mapper, so unreferenced files are deleted and the directory removed), and the next write rebuilds from scratch (`FindRoot` returns `NotFound` → `MakeCowRoot` creates a fresh empty mapper). Reopen-clear only runs in append mode, where the mapper reset raises no other read hazard: the read uses its captured snapshot rather than `meta->mapper_`, and `FreeMappingSnapshot` frees no file pages. So only `compression_` needed protecting, and the reader-side capture is sufficient.

Verified: full C++ suite incl. standby (partition-directory cleanup) and cloud passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new local-only cleanup path for manifests, letting the app remove local state without touching remote storage when needed.
* **Bug Fixes**
  * Improved snapshot install and reopen flows to use local-only cleanup in missing-remote scenarios.
  * Made read handling more robust by preserving compression context during value decoding.
* **Refactor**
  * Split manifest removal into local cleanup and remote deletion steps for clearer behavior and safer cloud storage handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->