### PR TITLE
docs: run scripts/format.sh before opening a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,9 @@ SDK tests (also run in CI): `python3 -m build --wheel` + pytest in `python/`; in
 
 ## Formatting
 
-`bash scripts/format.sh` — installs clang-format 18.1.8 on first run and formats the tree. Main branch has a format check in CI; run before committing. Style is Google-based with Allman braces, 4-space indent, right pointer alignment (see `.clang-format`).
+`bash scripts/format.sh` — installs clang-format 18.1.8 on first run and formats the tree. Style is Google-based with Allman braces, 4-space indent, right pointer alignment (see `.clang-format`).
+
+**Always run `bash scripts/format.sh` and commit any changes it makes before opening (or updating) a PR.** The main branch has a format check in CI that will fail the PR otherwise — hand-written code that looks fine often still gets re-wrapped by clang-format (e.g. a call that now fits on one line). Don't rely on writing conforming code by hand; run the script.
 
 ## Architecture
 


### PR DESCRIPTION
Makes the formatting step explicit in CLAUDE.md's Formatting section: run `bash scripts/format.sh` and commit its changes before opening/updating a PR. The main-branch CI format check fails a PR on any clang-format deviation, and hand-written code that looks fine often still gets re-wrapped (e.g. a call that fits on one line once an argument shortens) — so writing conforming code by hand isn't enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)