### PR TITLE
fix: check MakeCowRoot error before dereferencing cow_meta_ in Apply

### DIFF
--- a/src/tasks/batch_write_task.cpp
+++ b/src/tasks/batch_write_task.cpp
@@ -254,8 +254,8 @@ KvError BatchWriteTask::Apply()
     // directly go to low priority queue and wait for scheduling
     YieldToLowPQ();
     KvError err = MakeCowRoot();
-    cow_meta_.compression_->SampleAndBuildDictionaryIfNeeded(data_batch_);
     CHECK_KV_ERR(err);
+    cow_meta_.compression_->SampleAndBuildDictionaryIfNeeded(data_batch_);
     err = ApplyBatch(cow_meta_.root_id_, true);
     if (err != KvError::NoError)
     {


### PR DESCRIPTION
`BatchWriteTask::Apply()` called `cow_meta_.compression_->SampleAndBuildDictionaryIfNeeded(data_batch_)` **before** `CHECK_KV_ERR(err)` on the `MakeCowRoot` result. `MakeCowRoot` leaves `cow_meta_.compression_` null on its error return paths (it only populates the CoW meta on success or the NotFound branch), so a root-load failure crashed on the null deref instead of propagating the error.

Fix: move `CHECK_KV_ERR(err)` ahead of the compression dereference.

Audit finding #14. One-line change; no behavior change on the success path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in batch write processing by validating the write state earlier, helping avoid issues when preparing compressed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->