### PR TITLE
fix: use FindNoErase in FreeMappingSnapshot to avoid re-entrant erase UAF

### DIFF
--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -727,7 +727,14 @@ std::pair<MemCachedPage::Handle, KvError> PageManager::FindPage(
 void PageManager::FreeMappingSnapshot(MappingSnapshot *mapping)
 {
     const TableIdent &tbl = *mapping->tbl_ident_;
-    auto *entry = root_meta_mgr_.Find(tbl);
+    // FindNoErase, not Find: ~MappingSnapshot (and hence this call) can run
+    // from inside RootMetaMgr::Erase() -> ~RootMeta -> ~PageMapper when a
+    // dropped table's entry is being destroyed (e.g. a large-value table whose
+    // segment PageMapper holds the sole ref to its segment mapping snapshot).
+    // Find() would run ProcessPendingErase() re-entrantly, which clears the
+    // pending_erase_ vector the outer ProcessPendingErase() is still iterating
+    // -> use-after-free. A plain lookup avoids re-entering the erase logic.
+    auto *entry = root_meta_mgr_.FindNoErase(tbl);
     if (entry == nullptr)
     {
         return;


### PR DESCRIPTION
## Problem

`PageManager::FreeMappingSnapshot()` is called from `~MappingSnapshot`, which can run **from inside `RootMetaMgr::Erase()`**:

```
ProcessPendingErase()            // outer loop over pending_erase_ (a std::vector)
└─ Erase(table1)
   └─ entries_.erase() → ~RootMeta → ~PageMapper(segment_mapper_)
      └─ ~MappingSnapshot         // sole ref to the segment mapping snapshot
         └─ FreeMappingSnapshot()
            └─ root_meta_mgr_.Find(tbl)      // ← runs ProcessPendingErase() AGAIN
               └─ Erase(remaining tables) + pending_erase_.clear()
```

The nested `ProcessPendingErase()` `clear()`s the `pending_erase_` vector that the **outer** `ProcessPendingErase()` loop is still iterating → use-after-free on the destroyed `TableIdent` entries. The same re-entrancy can also destroy the entry `EvictIfNeeded()`'s LRU cursor points at.

### Trigger (deterministic, single-threaded)

Drop two tables where the first-queued one wrote large values (so it owns a live `segment_mapper_` whose snapshot is unreferenced elsewhere); reads on each pin/unpin queue both into `pending_erase_`; the next `Find`/`FindRoot` runs `ProcessPendingErase()` and hits the chain above.

## Fix

Use `FindNoErase()` instead of `Find()` in `FreeMappingSnapshot()`. `RecyclePage()` already guards against the identical hazard the same way (with an explanatory comment). `FreeMappingSnapshot()` only needs to locate the entry to detach the snapshot / return file pages and never needs pending-erase processing, so the change is semantically safe and mirrors the established pattern.

## Scope check

- `UpdateRoot` and `FinishIo` also call `Find`, but at the top level of the shard loop — never inside an `Erase`/destructor chain — so they are safe.
- `~MappingSnapshot` is the only destructor that reaches a `Find`-family call, so this is the sole instance of the pattern.
- The `EvictIfNeeded` LRU-cursor variant shares this root cause and is closed by the same fix.