### PR TITLE
fix: don't CHECK-abort on a failed index-page write held by the caller

### DIFF
--- a/src/tasks/batch_write_task.cpp
+++ b/src/tasks/batch_write_task.cpp
@@ -1026,7 +1026,21 @@ KvError BatchWriteTask::FlushIndexPage(MemCachedPage::Handle &idx_page,
     // Flushes the built index page.
     idx_page->SetPageId(page_id);
     KvError err = WritePage(idx_page);
-    CHECK_KV_ERR(err);
+    if (err != KvError::NoError)
+    {
+        // The write failed. WritePageCallback leaves a still-pinned page for
+        // the caller to reclaim (it cannot free a page the caller pins). Free
+        // it here, mirroring TruncateIndexPage: if the page was promoted into
+        // the active list on a successful sibling write it is no longer
+        // detached and must be left alone.
+        MemCachedPage *page = idx_page.Get();
+        idx_page.Reset();
+        if (page->IsDetached() && !page->IsPinned())
+        {
+            shard->IndexManager()->FreePage(page);
+        }
+        return err;
+    }
 
     // The parent node needs to be updated only when the index page splits and
     // the current page is either a newly generated page or the root page.

--- a/src/tasks/write_task.cpp
+++ b/src/tasks/write_task.cpp
@@ -13,6 +13,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "async_io_manager.h"
 #include "error.h"
+#include "fail_point.h"
 #include "file_gc.h"
 #include "storage/data_page.h"
 #include "storage/mem_cached_page.h"
@@ -456,6 +457,17 @@ KvError WriteTask::WaitPendingUploads()
 
 void WriteTask::WritePageCallback(VarPage page, KvError err)
 {
+#ifndef NDEBUG
+    // Test hook: fail the completion of one index-page (MemCachedPage) write so
+    // tests can drive the disk-error branch below while the submitting task
+    // still holds a pin on the page.
+    if (err == KvError::NoError &&
+        VarPageType(page.index()) == VarPageType::MemCachedPage &&
+        FailPoint::GetInstance().ShouldFail("IndexPageWriteFail"))
+    {
+        err = KvError::IoFail;
+    }
+#endif
     if (err != KvError::NoError)
     {
         write_err_ = err;
@@ -474,11 +486,19 @@ void WriteTask::WritePageCallback(VarPage page, KvError err)
         }
         else
         {
-            // Only free if it's still detached (i.e., not in active list).
-            if (idx_page->IsDetached())
+            // WritePage() adds a temporary IO pin on top of the submitting
+            // task's handle, so that task may still legitimately pin this page
+            // when the failed write completes: the completion runs from the
+            // shard loop while the WriteTask coroutine is suspended in
+            // WaitWrite holding its handle (e.g. FlushIndexPage /
+            // TruncateIndexPage). Drop only our IO pin here and reclaim the
+            // page just once, when it is detached and nothing else references
+            // it. If the caller still holds a pin, it frees the page after it
+            // observes the error; CHECK-aborting on the caller's legitimate
+            // pin was a bug.
+            handle.Reset();
+            if (idx_page->IsDetached() && !idx_page->IsPinned())
             {
-                handle.Reset();
-                CHECK(!idx_page->IsPinned());
                 shard->IndexManager()->FreePage(idx_page);
             }
         }

--- a/tests/persist.cpp
+++ b/tests/persist.cpp
@@ -557,3 +557,49 @@ TEST_CASE("append mode survives compression toggles across restarts",
     store.reset();
     CleanupStore(base_opts);
 }
+
+// Audit finding rank 13: a failed index-page (MemCachedPage) write must not
+// CHECK-abort the process. WritePage() takes a temporary IO pin on top of the
+// submitting task's handle, and the completion runs from the shard loop while
+// the WriteTask coroutine is suspended in WaitWrite holding that handle (via
+// FlushIndexPage). The error branch of WritePageCallback used to
+// CHECK(!IsPinned()) on the caller's legitimate pin -> SIGABRT. It must instead
+// surface the error to the client and leave the store usable.
+TEST_CASE("failed index-page write surfaces error without aborting",
+          "[persist][writepage_fail]")
+{
+    eloqstore::KvOptions opts = default_opts;
+    // Force WaitWrite() after every submitted page so the failed completion is
+    // driven while the caller still holds its pin.
+    opts.max_write_batch_pages = 1;
+    eloqstore::EloqStore *store = InitStore(opts);
+    eloqstore::TableIdent tbl_id = {"writepage-fail", 0};
+
+    // Enough keys to split into several leaves => at least one internal index
+    // page flushed through FinishIndexPage/FlushIndexPage.
+    std::vector<eloqstore::WriteDataEntry> entries;
+    entries.reserve(4000);
+    for (uint64_t i = 0; i < 4000; ++i)
+    {
+        entries.emplace_back(
+            Key(i), std::string(24, 'v'), 1, eloqstore::WriteOp::Upsert);
+    }
+    eloqstore::BatchWriteRequest req;
+    req.SetArgs(tbl_id, std::move(entries));
+
+    eloqstore::FailPoint::GetInstance().ArmOnce("IndexPageWriteFail");
+    store->ExecSync(&req);  // must not SIGABRT
+    REQUIRE(req.Error() != eloqstore::KvError::NoError);
+
+    // The store is still usable after the injected disk error.
+    {
+        std::vector<eloqstore::WriteDataEntry> ok_entries;
+        ok_entries.emplace_back(
+            Key(0), std::string("ok"), 2, eloqstore::WriteOp::Upsert);
+        eloqstore::BatchWriteRequest ok_req;
+        ok_req.SetArgs(eloqstore::TableIdent{"writepage-fail", 1},
+                       std::move(ok_entries));
+        store->ExecSync(&ok_req);
+        REQUIRE(ok_req.Error() == eloqstore::KvError::NoError);
+    }
+}

--- a/tests/persist.cpp
+++ b/tests/persist.cpp
@@ -589,6 +589,8 @@ TEST_CASE("failed index-page write surfaces error without aborting",
 
     eloqstore::FailPoint::GetInstance().ArmOnce("IndexPageWriteFail");
     store->ExecSync(&req);  // must not SIGABRT
+    // Disarm before REQUIRE so an unfired point can't leak into later tests.
+    eloqstore::FailPoint::GetInstance().Disarm();
     REQUIRE(req.Error() != eloqstore::KvError::NoError);
 
     // The store is still usable after the injected disk error.

--- a/tests/persist.cpp
+++ b/tests/persist.cpp
@@ -558,7 +558,7 @@ TEST_CASE("append mode survives compression toggles across restarts",
     CleanupStore(base_opts);
 }
 
-// Audit finding rank 13: a failed index-page (MemCachedPage) write must not
+// A failed index-page (MemCachedPage) write must not
 // CHECK-abort the process. WritePage() takes a temporary IO pin on top of the
 // submitting task's handle, and the completion runs from the shard loop while
 // the WriteTask coroutine is suspended in WaitWrite holding that handle (via

--- a/tests/persist.cpp
+++ b/tests/persist.cpp
@@ -510,6 +510,59 @@ TEST_CASE("write task abort rolls back branch file-id high-water (cloud)",
     REQUIRE(write(2, 64, 2) == eloqstore::KvError::NoError);
 }
 
+// A failed index-page (MemCachedPage) write must not
+// CHECK-abort the process. WritePage() takes a temporary IO pin on top of the
+// submitting task's handle, and the completion runs from the shard loop while
+// the WriteTask coroutine is suspended in WaitWrite holding that handle (via
+// FlushIndexPage). The error branch of WritePageCallback used to
+// CHECK(!IsPinned()) on the caller's legitimate pin -> SIGABRT. It must instead
+// surface the error to the client and leave the store usable.
+//
+// Keep this case before the append-mode one below: that test drives its own
+// EloqStore instances, which clears the global eloq_store pointer while the
+// static InitStore store keeps running, so a later InitStore teardown of that
+// store crashes in code reading the global (e.g. Prewarmer::Shutdown).
+TEST_CASE("failed index-page write surfaces error without aborting",
+          "[persist][writepage_fail]")
+{
+    eloqstore::KvOptions opts = default_opts;
+    // Force WaitWrite() after every submitted page so the failed completion is
+    // driven while the caller still holds its pin.
+    opts.max_write_batch_pages = 1;
+    eloqstore::EloqStore *store = InitStore(opts);
+    eloqstore::TableIdent tbl_id = {"writepage-fail", 0};
+
+    // Enough keys to split into several leaves => at least one internal index
+    // page flushed through FinishIndexPage/FlushIndexPage.
+    std::vector<eloqstore::WriteDataEntry> entries;
+    entries.reserve(4000);
+    for (uint64_t i = 0; i < 4000; ++i)
+    {
+        entries.emplace_back(
+            Key(i), std::string(24, 'v'), 1, eloqstore::WriteOp::Upsert);
+    }
+    eloqstore::BatchWriteRequest req;
+    req.SetArgs(tbl_id, std::move(entries));
+
+    eloqstore::FailPoint::GetInstance().ArmOnce("IndexPageWriteFail");
+    store->ExecSync(&req);  // must not SIGABRT
+    // Disarm before REQUIRE so an unfired point can't leak into later tests.
+    eloqstore::FailPoint::GetInstance().Disarm();
+    REQUIRE(req.Error() != eloqstore::KvError::NoError);
+
+    // The store is still usable after the injected disk error.
+    {
+        std::vector<eloqstore::WriteDataEntry> ok_entries;
+        ok_entries.emplace_back(
+            Key(0), std::string("ok"), 2, eloqstore::WriteOp::Upsert);
+        eloqstore::BatchWriteRequest ok_req;
+        ok_req.SetArgs(eloqstore::TableIdent{"writepage-fail", 1},
+                       std::move(ok_entries));
+        store->ExecSync(&ok_req);
+        REQUIRE(ok_req.Error() == eloqstore::KvError::NoError);
+    }
+}
+
 TEST_CASE("append mode survives compression toggles across restarts",
           "[persist]")
 {
@@ -556,52 +609,4 @@ TEST_CASE("append mode survives compression toggles across restarts",
     store->Stop();
     store.reset();
     CleanupStore(base_opts);
-}
-
-// A failed index-page (MemCachedPage) write must not
-// CHECK-abort the process. WritePage() takes a temporary IO pin on top of the
-// submitting task's handle, and the completion runs from the shard loop while
-// the WriteTask coroutine is suspended in WaitWrite holding that handle (via
-// FlushIndexPage). The error branch of WritePageCallback used to
-// CHECK(!IsPinned()) on the caller's legitimate pin -> SIGABRT. It must instead
-// surface the error to the client and leave the store usable.
-TEST_CASE("failed index-page write surfaces error without aborting",
-          "[persist][writepage_fail]")
-{
-    eloqstore::KvOptions opts = default_opts;
-    // Force WaitWrite() after every submitted page so the failed completion is
-    // driven while the caller still holds its pin.
-    opts.max_write_batch_pages = 1;
-    eloqstore::EloqStore *store = InitStore(opts);
-    eloqstore::TableIdent tbl_id = {"writepage-fail", 0};
-
-    // Enough keys to split into several leaves => at least one internal index
-    // page flushed through FinishIndexPage/FlushIndexPage.
-    std::vector<eloqstore::WriteDataEntry> entries;
-    entries.reserve(4000);
-    for (uint64_t i = 0; i < 4000; ++i)
-    {
-        entries.emplace_back(
-            Key(i), std::string(24, 'v'), 1, eloqstore::WriteOp::Upsert);
-    }
-    eloqstore::BatchWriteRequest req;
-    req.SetArgs(tbl_id, std::move(entries));
-
-    eloqstore::FailPoint::GetInstance().ArmOnce("IndexPageWriteFail");
-    store->ExecSync(&req);  // must not SIGABRT
-    // Disarm before REQUIRE so an unfired point can't leak into later tests.
-    eloqstore::FailPoint::GetInstance().Disarm();
-    REQUIRE(req.Error() != eloqstore::KvError::NoError);
-
-    // The store is still usable after the injected disk error.
-    {
-        std::vector<eloqstore::WriteDataEntry> ok_entries;
-        ok_entries.emplace_back(
-            Key(0), std::string("ok"), 2, eloqstore::WriteOp::Upsert);
-        eloqstore::BatchWriteRequest ok_req;
-        ok_req.SetArgs(eloqstore::TableIdent{"writepage-fail", 1},
-                       std::move(ok_entries));
-        store->ExecSync(&ok_req);
-        REQUIRE(ok_req.Error() == eloqstore::KvError::NoError);
-    }
 }


### PR DESCRIPTION
## Problem

`WriteTask::WritePage(Handle&, FilePageId)` takes a **temporary IO pin on top of the submitting task's handle**. When an index-page (`MemCachedPage`) write fails, the io_uring completion runs from the shard loop while the `WriteTask` coroutine is suspended in `WaitWrite` — still holding its handle, because `FlushIndexPage` / `TruncateIndexPage` keep their pin across the write.

`WritePageCallback`'s error branch then ran:

```cpp
handle.Reset();                    // drop only the IO pin
CHECK(!idx_page->IsPinned());      // <-- caller still legitimately pins it
shard->IndexManager()->FreePage(idx_page);
```

so **any disk error (EIO / ENOSPC / short write) `LOG(FATAL)`-aborts the whole store** instead of returning the error to the client and letting the task `Abort()`.

Only index pages are affected: the CHECK/free code is in the `MemCachedPage` switch arm only, and only `FlushIndexPage`/`TruncateIndexPage` keep a pin across the write (data/overflow pages are `std::move`d in, giving up ownership). The crash is specific to the `WaitWrite` path (`inflight_io_ >= max_write_batch_pages`), which parks the coroutine holding the pin until the completion — the callback — unblocks it. The `YieldToLowPQ` path releases the pin before the completion is ever polled.

## Fix

Mirror `TruncateIndexPage`'s existing caller-frees-on-error pattern:

- **`WritePageCallback`**: drop only the IO pin, then reclaim the page just once — only when it is detached **and** no longer referenced. If the caller still holds a pin, it frees the page after observing the error. Never `CHECK`/abort on the caller's pin.
- **`FlushIndexPage`**: on `WritePage` error, free its detached page (the `FinishIndexPage`/`Pop` path previously leaked it) before returning the error.

Exactly one of callback/caller frees the page. The callback runs first (it sets `write_err_`), so if the caller has not yet observed the error and still pins the page, the callback defers and the caller frees; otherwise the callback is the last owner and frees it. `IsDetached()` also guards against double-free (a freed page is linked on the free list → not detached) and against freeing a page a sibling write promoted into the cache.

## Reproduction / test

Adds a debug-only `FailPoint("IndexPageWriteFail")` that turns one index-page write completion into `KvError::IoFail`, plus a `persist` regression test (`[writepage_fail]`) that:

- **before the fix**: `write_task.cpp] Check failed: !idx_page->IsPinned()` → SIGABRT;
- **after the fix**: the batch write returns an error (no abort) and the store remains usable for subsequent writes.

Verified: `./build/tests/persist "failed index-page write surfaces error without aborting"` → `All tests passed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where failed index-page writes could leave pages incorrectly pinned or cause an application abort.
  * Write failures now surface as errors while allowing the store to remain usable for subsequent writes.

* **Tests**
  * Added regression coverage for injected index-page write failures and successful recovery afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->