### PR TITLE
fix: FileCleaner use-after-free when GetSQE suspends mid-cleanup

### DIFF
--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -6005,6 +6005,8 @@ int CloudStoreMgr::ReserveCacheSpace(size_t size)
             LOG(WARNING) << "Cannot reserve " << size
                          << " bytes: used=" << used_local_space_
                          << " limit=" << shard_local_space_limit_
+                         << " open_fds=" << lru_fd_count_ << "/" << fd_limit_
+                         << " closed_files=" << closed_files_.size()
                          << " no evictable files" << " task=" << current_task;
             return -ENOSPC;
         }

--- a/src/async_io_manager.cpp
+++ b/src/async_io_manager.cpp
@@ -6903,16 +6903,17 @@ void CloudStoreMgr::FileCleaner::Run()
                 it = io_mgr_->pending_gc_cleanup_.erase(it);
                 made_progress = true;
 
+                // Collect only: do NOT call GetSQE here. GetSQE can suspend
+                // (SQ ring full), and while suspended another same-shard
+                // coroutine can insert into pending_gc_cleanup_ (rehash) or
+                // erase from it, invalidating `it` -> use-after-free on the
+                // next iteration. The SQEs are submitted in a single pass below
+                // once no set iterator is held. StartEvictingKey (above) keeps
+                // req.file_ alive across that later suspension.
                 UnlinkReq &req = unlink_reqs[req_count++];
                 req.file_ = file;
                 req.path_ = file->key_->tbl_id_.ToString();
                 req.path_ /= file->key_->filename_;
-
-                io_uring_sqe *sqe =
-                    io_mgr_->GetSQE(UserDataType::BaseReq, &req);
-                int root_fd = io_mgr_->GetRootFD(file->key_->tbl_id_).first;
-                DLOG(INFO) << "FileCleaner GC:" << req.path_;
-                io_uring_prep_unlinkat(sqe, root_fd, req.path_.c_str(), 0);
             }
         }
 
@@ -6940,18 +6941,30 @@ void CloudStoreMgr::FileCleaner::Run()
                     continue;
                 }
 
+                // Collect only, same as the pending-GC loop above: GetSQE must
+                // not run while the intrusive lru_file_ list pointer `file` is
+                // held, since a suspension there could let another coroutine
+                // evict/free the node -> dangling `file`/`file->prev_`.
                 UnlinkReq &req = unlink_reqs[req_count++];
                 req.file_ = file;
                 req.path_ = file->key_->tbl_id_.ToString();
                 req.path_ /= file->key_->filename_;
-
-                io_uring_sqe *sqe =
-                    io_mgr_->GetSQE(UserDataType::BaseReq, &req);
-                int root_fd =
-                    io_mgr_->GetRootFD(req.file_->key_->tbl_id_).first;
-                DLOG(INFO) << "FileCleaner eviction:" << req.path_;
-                io_uring_prep_unlinkat(sqe, root_fd, req.path_.c_str(), 0);
             }
+        }
+
+        // Submit pass: no pending_gc_cleanup_ iterator or lru_file_ list
+        // pointer is held here, so GetSQE()/GetRootFD() may safely suspend when
+        // the SQ ring is full. Each req.file_ was pinned via StartEvictingKey
+        // during collection, so it stays valid (unordered_map element pointers
+        // survive rehash; an evicting key is not erased until the completion
+        // pass below).
+        for (uint16_t i = 0; i < req_count; i++)
+        {
+            UnlinkReq &req = unlink_reqs[i];
+            io_uring_sqe *sqe = io_mgr_->GetSQE(UserDataType::BaseReq, &req);
+            int root_fd = io_mgr_->GetRootFD(req.file_->key_->tbl_id_).first;
+            DLOG(INFO) << "FileCleaner unlink:" << req.path_;
+            io_uring_prep_unlinkat(sqe, root_fd, req.path_.c_str(), 0);
         }
 
         if (req_count == 0)


### PR DESCRIPTION
## Problem

`CloudStoreMgr::FileCleaner::Run` submitted unlink SQEs from **inside** its two collection loops:

- the GC loop held a `pending_gc_cleanup_` (`unordered_set`) iterator across `GetSQE()`;
- the pressure-eviction loop held an intrusive `lru_file_` list pointer across `GetSQE()`.

`GetSQE()` suspends the coroutine when the SQ ring is full (`waiting_sqe_.Wait`). While it is suspended, other coroutines on the same shard mutate the set — `ScheduleLocalFileCleanup` inserts (a rehash invalidates **every** iterator) and `OpenFile`/`DequeClosedFile` erase — or evict/free an `lru_file_` node. `PollComplete` resumes IO-completed tasks *before* waking `waiting_sqe_` waiters, so a mutating task runs before the parked cleaner by design.

On resume the loop dereferences/erases a dangling iterator or follows a freed list pointer → **use-after-free** (shard-state corruption or crash) under cloud-mode write/GC load.

## Fix

Separate collection from submission:

- both loops now only fill the fixed `unlink_reqs[]` array (no `GetSQE`);
- a single pass afterwards issues `GetSQE()` / `GetRootFD()` / `prep_unlinkat` over `unlink_reqs` by index.

No set iterator or list pointer is ever live across a suspension. Each `req.file_` is pinned via `StartEvictingKey` during collection, so it stays valid across the submit pass's suspensions (`unordered_map` element pointers survive a rehash; an evicting key is not erased until the completion pass). The batch size and request count are unchanged.

## Testing

The interleaving needs a full SQ ring plus a concurrent set mutation during the suspension, which has no clean deterministic injection point; verified functionally against the FileCleaner-heavy cloud GC suites (`large_value_gc`, `segment_compact`), both green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache cleanup reliability by making eviction/unlink handling more robust, reducing the chance of cleanup failing.
  * Enhanced warning logs when cache space can’t be reserved to include current `open_fds` and `closed_files` counts for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->