### PR TITLE
fix: complete requests racing Stop() instead of crashing or hanging

### DIFF
--- a/include/eloq_store.h
+++ b/include/eloq_store.h
@@ -996,6 +996,12 @@ public:
 
 private:
     bool SendRequest(KvRequest *req);
+    // Submit @p req to an arbitrary shard and block until it completes. Used by
+    // the global cloud-listing handlers, which are not tied to a partition, so
+    // any shard can serve them. If the store is stopping the shard refuses the
+    // request; it is then completed with NotRunning instead of hanging. const
+    // so the const CollectTablePartitions helper can share it.
+    void ExecSyncOnAnyShard(KvRequest *req) const;
     void HandleDropTableRequest(DropTableRequest *req);
     void HandleGlobalArchiveRequest(GlobalArchiveRequest *req);
     void HandleGlobalReopenRequest(GlobalReopenRequest *req);

--- a/include/storage/shard.h
+++ b/include/storage/shard.h
@@ -128,6 +128,14 @@ private:
 
     void InitializeTscFrequency();
 
+    // Complete every request still queued on this shard with NotRunning when
+    // the shard's loop exits during shutdown. SendRequest's Running gate is
+    // advisory (a submitter can enqueue after the shard decides to exit), so
+    // without this drain those requests would never complete and their callers
+    // would block in Wait() forever. Runs on the shard thread (WorkLoop) or the
+    // module worker (WorkOneRound), the sole consumer of requests_.
+    void DrainPendingRequests();
+
     uint64_t ReadTimeMicroseconds();
 
     uint64_t DurationMicroseconds(uint64_t start_us);

--- a/src/eloq_store.cpp
+++ b/src/eloq_store.cpp
@@ -550,6 +550,11 @@ EloqStore::~EloqStore()
     {
         Stop();
     }
+    // Stop() retains shards_ (see CleanupRuntime). Destroy them here, while
+    // cloud_service_/standby_service_ are still alive, since a shard's io
+    // manager may reference those services during teardown and standby_service_
+    // is declared after shards_ (so it would otherwise be destroyed first).
+    shards_.clear();
 }
 
 void EloqStore::CleanupRuntime(size_t started_shards)
@@ -615,8 +620,13 @@ void EloqStore::CleanupRuntime(size_t started_shards)
         }
     }
 
-    shards_.clear();
-
+    // NB: shards_ is intentionally NOT cleared here. SendRequest indexes
+    // shards_ (shards_[TableId().ShardIndex(shards_.size())]) after only an
+    // advisory status check, so destroying the vector concurrently would race
+    // that access -> shards_.size()==0 gives partition_id_ % 0 (SIGFPE) or a
+    // dangling shard deref. The stopped shards stay valid (their AddKvRequest
+    // returns NotRunning); the vector is torn down instead at the next Start()
+    // or in ~EloqStore, where no request submission can be in flight.
     for (int fd : root_fds_)
     {
         [[maybe_unused]] int res = close(fd);
@@ -811,6 +821,11 @@ KvError EloqStore::Start(std::string_view branch,
               << ", num_threads=" << options_.num_threads
               << ", shard_fd_limit=" << shard_fd_limit;
 
+    // A prior Stop() retained its shards_ (see CleanupRuntime); drop them now,
+    // before rebuilding. This runs during Start (status is Starting, so no
+    // request submission proceeds past SendRequest's gate), so it cannot race a
+    // shards_ access.
+    shards_.clear();
     shards_.resize(options_.num_threads);
     for (size_t i = 0; i < options_.num_threads; i++)
     {
@@ -1184,9 +1199,7 @@ KvError EloqStore::CollectTablePartitions(
             list_object_request.GetNextContinuationToken()->clear();
             objects.clear();
 
-            shards_[utils::RandomInt(static_cast<int>(shards_.size()))]
-                ->AddKvRequest(&list_object_request);
-            list_object_request.Wait();
+            ExecSyncOnAnyShard(&list_object_request);
 
             KvError list_err = list_object_request.Error();
             if (list_err != KvError::NoError)
@@ -1439,9 +1452,7 @@ void EloqStore::HandleGlobalArchiveRequest(GlobalArchiveRequest *req)
             list_request.err_ = KvError::NoError;
             list_request.GetNextContinuationToken()->clear();
             objects.clear();
-            shards_[utils::RandomInt(static_cast<int>(shards_.size()))]
-                ->AddKvRequest(&list_request);
-            list_request.Wait();
+            ExecSyncOnAnyShard(&list_request);
 
             if (list_request.Error() != KvError::NoError)
             {
@@ -1626,9 +1637,7 @@ void EloqStore::HandleGlobalReopenRequest(GlobalReopenRequest *req)
         list_request.done_.store(false, std::memory_order_relaxed);
 #endif
         list_request.err_ = KvError::NoError;
-        shards_[utils::RandomInt(static_cast<int>(shards_.size()))]
-            ->AddKvRequest(&list_request);
-        list_request.Wait();
+        ExecSyncOnAnyShard(&list_request);
         if (list_request.Error() != KvError::NoError)
         {
             req->SetDone(list_request.Error());
@@ -2204,6 +2213,22 @@ bool EloqStore::SendRequest(KvRequest *req)
 
     Shard *shard = shards_[req->TableId().ShardIndex(shards_.size())].get();
     return shard->AddKvRequest(req);
+}
+
+void EloqStore::ExecSyncOnAnyShard(KvRequest *req) const
+{
+    if (shards_[utils::RandomInt(static_cast<int>(shards_.size()))]
+            ->AddKvRequest(req))
+    {
+        req->Wait();
+    }
+    else
+    {
+        // AddKvRequest refuses new work once the store is stopping; complete
+        // the request with NotRunning instead of waiting on one that was never
+        // enqueued. Anything already enqueued is caught by the shard's drain.
+        req->SetDone(KvError::NotRunning);
+    }
 }
 
 void EloqStore::Stop()

--- a/src/eloq_store.cpp
+++ b/src/eloq_store.cpp
@@ -2012,8 +2012,18 @@ void EloqStore::HandleGlobalCreateBranchRequest(GlobalCreateBranchRequest *req)
         list_request.SetRecursive(false);
         do
         {
+            // ExecSyncOnAnyShard bypasses SendRequest, so it does not reset
+            // done_; reset it before each reuse or Wait() would return early.
+#ifdef ELOQ_MODULE_ENABLED
+            {
+                std::lock_guard<bthread::Mutex> lk(list_request.mutex_);
+                list_request.done_ = false;
+            }
+#else
+            list_request.done_.store(false, std::memory_order_relaxed);
+#endif
             objects.clear();
-            ExecSync(&list_request);
+            ExecSyncOnAnyShard(&list_request);
 
             if (list_request.Error() != KvError::NoError)
             {

--- a/src/storage/shard.cpp
+++ b/src/storage/shard.cpp
@@ -209,6 +209,9 @@ void Shard::WorkLoop()
 #endif
     }
 
+    // Complete any requests that raced Stop() into the queue before tearing
+    // down, so their callers don't hang forever.
+    DrainPendingRequests();
     task_mgr_.Shutdown();
     // Unfinished tasks may still own MemCachedPage::Handle instances.
     // Release task state before tearing down the index-page pool they
@@ -259,8 +262,40 @@ void Shard::Stop()
 #endif
 }
 
+void Shard::DrainPendingRequests()
+{
+    KvRequest *req = nullptr;
+    [[maybe_unused]] size_t drained = 0;
+    while (requests_.try_dequeue(req))
+    {
+        req->SetDone(KvError::NotRunning);
+        ++drained;
+    }
+    for (DelayedEntry &entry : delayed_requests_)
+    {
+        entry.request->SetDone(KvError::NotRunning);
+    }
+    delayed_requests_.clear();
+#ifdef ELOQ_MODULE_ENABLED
+    if (drained > 0)
+    {
+        req_queue_size_.fetch_sub(drained, std::memory_order_relaxed);
+    }
+#endif
+}
+
 bool Shard::AddKvRequest(KvRequest *req)
 {
+    // The store is stopping: refuse new work instead of enqueuing into a queue
+    // whose consumer is exiting. Returning false (without completing the
+    // request) matches SendRequest's contract -- ExecSync completes it with
+    // NotRunning, ExecAsyn returns false to the caller, and the internal
+    // OOM-retry re-enqueue site completes it explicitly. Anything already
+    // enqueued before this flag was observed is caught by DrainPendingRequests.
+    if (io_mgr_->IsStoreStopping())
+    {
+        return false;
+    }
     bool ret = requests_.enqueue(req);
 #ifdef ELOQ_MODULE_ENABLED
     if (ret)
@@ -1004,7 +1039,12 @@ void Shard::OnTaskFinished(KvTask *task)
 #else
         req->done_.store(false, std::memory_order_relaxed);
 #endif
-        AddKvRequest(req);
+        // AddKvRequest refuses new work once the store is stopping; complete
+        // the retried request with NotRunning instead of dropping it.
+        if (!AddKvRequest(req))
+        {
+            req->SetDone(KvError::NotRunning);
+        }
         return;
     }
 
@@ -1045,6 +1085,7 @@ void Shard::WorkOneRound()
     {
         if (stop_requested)
         {
+            DrainPendingRequests();
             task_mgr_.Shutdown();
             index_mgr_.Shutdown();
             io_mgr_->Stop();

--- a/tests/persist.cpp
+++ b/tests/persist.cpp
@@ -537,3 +537,67 @@ TEST_CASE("append mode survives compression toggles across restarts",
     store.reset();
     CleanupStore(base_opts);
 }
+
+// Requests submitted concurrently with Stop() must all complete: none may be
+// stranded in a shard queue whose consumer exited, and Stop() must not crash on
+// the shards_ vector. Before the fix, a submitter racing Stop() could index a
+// torn-down shards_ (partition_id_ % 0 -> SIGFPE) or enqueue into a queue that
+// was never drained, hanging its caller forever. Each iteration submits from a
+// separate thread while the main thread stops; then Start() again (exercises
+// shards_ retention + rebuild). ExecAsyn is non-blocking, so a regression shows
+// up as a crash or an accepted-but-not-done request, never as a test hang.
+TEST_CASE("requests racing Stop all complete", "[persist][shutdown]")
+{
+    eloqstore::EloqStore *store = InitStore(default_opts);
+
+    constexpr int kIters = 8;
+    constexpr int kReqs = 400;
+    for (int iter = 0; iter < kIters; ++iter)
+    {
+        if (iter > 0)
+        {
+            REQUIRE(store->Start(eloqstore::MainBranchName, 0) ==
+                    eloqstore::KvError::NoError);
+        }
+
+        std::vector<eloqstore::BatchWriteRequest> reqs(kReqs);
+        std::vector<char> accepted(kReqs, 0);
+        std::atomic<int> submitted{0};
+
+        std::thread submitter(
+            [&]
+            {
+                for (int i = 0; i < kReqs; ++i)
+                {
+                    std::vector<eloqstore::WriteDataEntry> batch;
+                    batch.emplace_back(Key(i),
+                                       std::to_string(i),
+                                       1,
+                                       eloqstore::WriteOp::Upsert);
+                    reqs[i].SetArgs(
+                        eloqstore::TableIdent{"race", static_cast<uint32_t>(i)},
+                        std::move(batch));
+                    accepted[i] = store->ExecAsyn(&reqs[i]) ? 1 : 0;
+                    submitted.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+
+        // Let the submitter get underway so Stop() genuinely races in-flight
+        // submissions rather than completing before the thread ramps up.
+        while (submitted.load(std::memory_order_relaxed) < kReqs / 4)
+        {
+            std::this_thread::yield();
+        }
+        store->Stop();
+        submitter.join();
+
+        // Every accepted request completed (processed or drained NotRunning).
+        for (int i = 0; i < kReqs; ++i)
+        {
+            if (accepted[i])
+            {
+                REQUIRE(reqs[i].IsDone());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Shutdown had no clean handoff with request submission, so a request that raced `Stop()` could crash the process or hang its caller forever:

1. **Crash.** `SendRequest` checked `status == Running` once, then indexed `shards_[TableId().ShardIndex(shards_.size())]`. `CleanupRuntime` cleared `shards_` after joining the shard threads, so a submitter preempted between the check and the index could hit an emptied vector → `partition_id_ % 0` (SIGFPE) or a dangling shard deref.
2. **Hang.** `Shard::WorkLoop` / `WorkOneRound` exited on idle+stopping **without draining `requests_`**, and `AddKvRequest` enqueued unconditionally. A request enqueued around the shard's exit was never completed, and `KvRequest::Wait()` has no timeout, so the caller blocked forever.
3. **Fan-out hang / archive deadlock.** The global cloud-listing handlers (drop-table, archive, reopen) and the OOM-retry re-enqueue used a raw `AddKvRequest` and ignored the return, so they also hung on stop. The archive cron runs `ExecSync(GlobalArchiveRequest)` on a thread that `CleanupRuntime` joins, so this could deadlock `Stop()`.

## Fix (no per-request synchronization added)

- **Retain `shards_` across `Stop()`** — it is no longer cleared in `CleanupRuntime`; it is torn down instead at the next `Start()` and in `~EloqStore`, where no submission can be in flight. A stopped shard remains a valid object whose `AddKvRequest` returns `NotRunning`, so a racing `SendRequest` can no longer crash on an emptied/dangling vector. `~EloqStore` clears it while `cloud_service_`/`standby_service_` (declared after `shards_`) are still alive, since a shard's io manager references them during teardown.
- **Refuse + drain.** `AddKvRequest` refuses new work once `IsStoreStopping()`; `Shard::DrainPendingRequests()` completes anything already queued (`requests_` + `delayed_requests_`) with `NotRunning`, called from **both** `WorkLoop` and `WorkOneRound` before teardown.
- **Shared helper.** The three global list handlers now share `ExecSyncOnAnyShard()`, which completes the request with `NotRunning` when the shard refuses it (fixes the fan-out hang and the archive-cron self-deadlock). The OOM-retry re-enqueue site completes its request explicitly on refusal.

### Why not a flag alone / why not a counter

A single "stopping" flag checked in `SendRequest` can't close the window: a submitter that already passed the check can still index a torn-down `shards_`. Retaining `shards_` removes that (the access is always valid). Fully closing the last "submitter descheduled across the entire teardown, enqueues after the drain" window would need producer-side quiescence (a counter); that per-request atomic was deliberately avoided, so that residual is bounded by the usual contract that the embedder stops issuing new submissions once `Stop()` begins. Everything already queued, plus all the crash/deadlock paths, are covered.

## Test

`persist` `[shutdown]`: a separate thread submits requests while the main thread stops (repeated, with `Start()` in between to exercise `shards_` retention + rebuild). Every accepted request must complete and `Stop()` must not crash. `ExecAsyn` is non-blocking, so a regression surfaces as a crash or an accepted-but-not-done request, never as a test hang.

Verified against the lifecycle/cloud suites: `persist` (excl. the slow overflow case), `concurrency`, `eloq_store_test`, `cloud`, `large_value_gc` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling so queued/in-flight requests are drained and completed instead of hanging.
  * Requests submitted during store stopping now fail fast with a clear “not running” result.
  * Improved cloud listing behavior by safely synchronizing execution on any shard during startup/shutdown.
  * Prevented requests from being dropped in retry paths during shutdown.
* **Tests**
  * Added a concurrency regression test to ensure requests submitted while stopping (with restart) always complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->