### PR TITLE
fix: match the ETag response header case-insensitively

### DIFF
--- a/include/storage/object_store.h
+++ b/include/storage/object_store.h
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -286,6 +287,15 @@ public:
         std::vector<std::string> *objects,
         std::vector<utils::CloudObjectInfo> *infos,
         std::string *next_continuation_token = nullptr) const;
+
+    // Parse the ETag value from a single HTTP response header line. The header
+    // name is matched case-insensitively -- HTTP header names are
+    // case-insensitive and HTTP/2 delivers them lowercased ("etag:"), so a
+    // byte-exact "ETag:" match would miss it on HTTP/2 endpoints (e.g. GCS).
+    // Returns the unquoted value, or nullopt if the line is not an ETag header
+    // or carries no value.
+    static std::optional<std::string> ParseETagHeader(
+        std::string_view header_line);
 
 private:
     void CleanupTaskResources(ObjectStore::Task *task);

--- a/src/storage/object_store.cpp
+++ b/src/storage/object_store.cpp
@@ -2,6 +2,7 @@
 
 #include <aws/core/Aws.h>
 #include <glog/logging.h>
+#include <strings.h>
 
 #include <algorithm>
 #include <chrono>
@@ -905,6 +906,55 @@ size_t AsyncHttpManager::WriteCallback(void *contents,
     return total;
 }
 
+std::optional<std::string> AsyncHttpManager::ParseETagHeader(
+    std::string_view header_line)
+{
+    // Match the header name case-insensitively. HTTP header names are
+    // case-insensitive and HTTP/2 delivers them lowercased ("etag:"); a
+    // byte-exact "ETag:" compare misses them on HTTP/2 endpoints (e.g. GCS),
+    // leaving etag_ empty and degrading the term-file CAS to an unconditional
+    // PUT (silent loss of split-brain fencing).
+    constexpr std::string_view etag_prefix = "ETag:";
+    if (header_line.size() < etag_prefix.size() ||
+        strncasecmp(
+            header_line.data(), etag_prefix.data(), etag_prefix.size()) != 0)
+    {
+        return std::nullopt;
+    }
+
+    // Skip whitespace after the colon.
+    size_t value_start = etag_prefix.size();
+    while (
+        value_start < header_line.size() &&
+        (header_line[value_start] == ' ' || header_line[value_start] == '\t'))
+    {
+        ++value_start;
+    }
+
+    // Value runs to end of line.
+    size_t value_end = value_start;
+    while (value_end < header_line.size() && header_line[value_end] != '\r' &&
+           header_line[value_end] != '\n')
+    {
+        ++value_end;
+    }
+
+    if (value_end <= value_start)
+    {
+        return std::nullopt;
+    }
+
+    std::string_view etag_value =
+        header_line.substr(value_start, value_end - value_start);
+    // Strip surrounding quotes if present.
+    if (etag_value.size() >= 2 && etag_value.front() == '"' &&
+        etag_value.back() == '"')
+    {
+        etag_value = etag_value.substr(1, etag_value.size() - 2);
+    }
+    return std::string(etag_value);
+}
+
 size_t AsyncHttpManager::HeaderCallback(char *buffer,
                                         size_t size,
                                         size_t nitems,
@@ -916,41 +966,10 @@ size_t AsyncHttpManager::HeaderCallback(char *buffer,
         return size * nitems;
     }
 
-    // Extract ETag header: "ETag: "value"\r\n"
     std::string_view header_line(buffer, size * nitems);
-    constexpr std::string_view etag_prefix = "ETag:";
-    if (header_line.size() >= etag_prefix.size() &&
-        header_line.substr(0, etag_prefix.size()) == etag_prefix)
+    if (std::optional<std::string> etag = ParseETagHeader(header_line))
     {
-        // Find the value after "ETag: "
-        size_t value_start = etag_prefix.size();
-        while (value_start < header_line.size() &&
-               (header_line[value_start] == ' ' ||
-                header_line[value_start] == '\t'))
-        {
-            ++value_start;
-        }
-
-        // Extract value (may be quoted)
-        size_t value_end = value_start;
-        while (value_end < header_line.size() &&
-               header_line[value_end] != '\r' && header_line[value_end] != '\n')
-        {
-            ++value_end;
-        }
-
-        if (value_end > value_start)
-        {
-            std::string_view etag_value =
-                header_line.substr(value_start, value_end - value_start);
-            // Remove quotes if present
-            if (etag_value.size() >= 2 && etag_value.front() == '"' &&
-                etag_value.back() == '"')
-            {
-                etag_value = etag_value.substr(1, etag_value.size() - 2);
-            }
-            task->etag_ = std::string(etag_value);
-        }
+        task->etag_ = std::move(*etag);
     }
 
     return size * nitems;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(UTEST_SOURCES
     iouring_tail_scratch.cpp
     segment_allocator.cpp
     data_page_cache.cpp
+    object_store_etag.cpp
 )
 
 string( REPLACE ".cpp" "" BASENAMES_UTEST "${UTEST_SOURCES}" )

--- a/tests/object_store_etag.cpp
+++ b/tests/object_store_etag.cpp
@@ -1,0 +1,40 @@
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+
+#include "storage/object_store.h"
+
+// The ETag response header must be matched case-insensitively: HTTP header
+// names are case-insensitive and HTTP/2 (e.g. GCS) delivers them lowercased.
+// A byte-exact "ETag:" match would leave etag_ empty on HTTP/2, silently
+// downgrading the term-file compare-and-swap to an unconditional PUT.
+TEST_CASE("ParseETagHeader matches the header name case-insensitively",
+          "[object_store]")
+{
+    using eloqstore::AsyncHttpManager;
+
+    // HTTP/1.1 style (capitalized, quoted).
+    auto h1 = AsyncHttpManager::ParseETagHeader("ETag: \"abc123\"\r\n");
+    REQUIRE(h1.has_value());
+    REQUIRE(*h1 == "abc123");
+
+    // HTTP/2 style (lowercased) -- the case this fix targets.
+    auto h2 = AsyncHttpManager::ParseETagHeader("etag: \"abc123\"\r\n");
+    REQUIRE(h2.has_value());
+    REQUIRE(*h2 == "abc123");
+
+    // Mixed case, tab separator, unquoted weak validator.
+    auto h3 = AsyncHttpManager::ParseETagHeader("Etag:\tW/xyz\r\n");
+    REQUIRE(h3.has_value());
+    REQUIRE(*h3 == "W/xyz");
+
+    // Non-ETag header is ignored.
+    REQUIRE_FALSE(
+        AsyncHttpManager::ParseETagHeader("Content-Length: 5\r\n").has_value());
+
+    // ETag header with no value.
+    REQUIRE_FALSE(AsyncHttpManager::ParseETagHeader("etag:\r\n").has_value());
+
+    // Shorter than the prefix.
+    REQUIRE_FALSE(AsyncHttpManager::ParseETagHeader("eta").has_value());
+}


### PR DESCRIPTION
## Problem

`AsyncHttpManager::HeaderCallback` extracted the ETag with a **byte-exact** `"ETag:"` prefix compare. HTTP header names are case-insensitive, and HTTP/2 delivers them lowercased (`etag:`) — curl negotiates HTTP/2 by default over TLS (`CURL_HTTP_VERSION_2TLS`), so against an h2 endpoint (e.g. GCS) `task->etag_` stayed empty.

`BootstrapUpsertTermFile` then issued the term-file update with an empty ETag, so `SetupUploadRequest` added neither `If-Match` nor `If-None-Match`: the compare-and-swap that fences zombie writers after failover silently degraded to an **unconditional PUT**, reopening the split-brain window it exists to close (two nodes can both "win" the term-file CAS and write the same partitions).

AWS S3 (HTTP/1.1) and the plain-HTTP MinIO CI config send `ETag` (capitalized) and were unaffected — which is exactly why existing tests never caught it.

## Fix

Match the header **name** case-insensitively (`strncasecmp`); the value is untouched. The ETag parsing is extracted into a pure, unit-testable `AsyncHttpManager::ParseETagHeader`.

## Test

`object_store_etag` unit test feeds the parser header lines directly, so the case handling is exercised **offline** — no HTTP/2 server needed (the e2e MinIO path can't reproduce this, since MinIO sends `ETag`). It asserts `ETag:`, lowercase `etag:`, and mixed-case `Etag:\t…` all parse, and that non-ETag / empty / too-short lines are rejected.