### PR TITLE
fix: don't disable TTL cleanup when a scan error interrupts CleanExpiredKeys

### DIFF
--- a/src/tasks/batch_write_task.cpp
+++ b/src/tasks/batch_write_task.cpp
@@ -2027,6 +2027,7 @@ KvError BatchWriteTask::CleanExpiredKeys()
     const uint64_t now_ts_ms = utils::UnixTs<chrono::milliseconds>();
     const uint64_t now_ts_us = utils::UnixTs<chrono::microseconds>();
     uint64_t next_expire_ts = 0;
+    KvError scan_err = KvError::NoError;
     do
     {
         std::string_view ttl_key = iter.Key();
@@ -2040,7 +2041,18 @@ KvError BatchWriteTask::CleanExpiredKeys()
         std::string key(ttl_key.substr(8));
         data_batch.emplace_back(
             std::move(key), "", now_ts_us, WriteOp::Delete, expire_ts);
-    } while (iter.Next() == KvError::NoError);
+        scan_err = iter.Next();
+    } while (scan_err == KvError::NoError);
+
+    // Real IO error (not EndOfFile): only a prefix of the expired keys was
+    // scanned. Aborting leaves next_expire_ts_ armed so the next TriggerTTL
+    // retries; committing would set it to 0 below and silently disable TTL.
+    if (scan_err != KvError::NoError && scan_err != KvError::EndOfFile)
+    {
+        LOG(ERROR) << "clean expired keys interrupted by scan error: "
+                   << ErrorString(scan_err);
+        return scan_err;
+    }
 
     if (ttl_batch.empty())
     {


### PR DESCRIPTION
## Problem

`CleanExpiredKeys` collects expired keys with `do { ... } while (iter.Next() == KvError::NoError)`. `ScanIterator::Next()` returns `EndOfFile` at the end of the TTL tree but a real error (`IoFail`, `Corrupted`, …) when paging it fails (EIO, a cloud fetch failure). The loop treats **both** the same: it stops having seen only a **prefix** of the expired keys, then commits the partial deletion and sets `next_expire_ts_ = 0`.

`TriggerTTL` early-returns on `next_expire_ts_ == 0`, and it is the **only** producer of TTL work (there is no periodic timer). So after one transient scan error the partition's TTL cleanup stays **disabled** until a later TTL upsert / `RootMeta` reload / reopen / restart re-arms `next_expire_ts_`. The unscanned expired keys linger on disk and — since reads don't filter expired keys server-side — stay readable, with no error surfaced (the cleanup request is fire-and-forget). Consistency is fine (both trees update atomically); it's a silent space/staleness leak, unbounded in a partition that stops receiving TTL writes.

The `Seek()` error just above the loop already distinguishes `EndOfFile` from a real error; the `Next()` loop didn't.

## Fix

Capture `Next()`'s result. On a real error (not `EndOfFile`), abort without committing so `next_expire_ts_` stays armed (still `<= now`) and the next `TriggerTTL` retries the whole scan; `EndOfFile` still commits `next_expire_ts_ = 0` as before (genuinely nothing left to expire — re-armed later by new TTL upserts via `UpdateTTL`).

## Test

Happy-path TTL behavior is unchanged — `delete.cpp` `[TTL]` tests pass. The error path itself has no clean deterministic hook (the cleanup runs as an async task and would need scan-path fault injection), so it isn't separately tested.