### PR TITLE
fix: free large-value segment pages on full-partition Truncate

### DIFF
--- a/src/tasks/batch_write_task.cpp
+++ b/src/tasks/batch_write_task.cpp
@@ -1859,6 +1859,27 @@ KvError BatchWriteTask::Truncate(std::string_view trunc_pos)
             FreePage(page_id);
         }
 
+        // Also free the large-value segment pages. Without this the segment
+        // mapping stays populated and is serialized into the empty snapshot, so
+        // GC keeps the segment files forever (only DropTable would reclaim
+        // them). The partial-truncate path frees these via DelLargeValue.
+        if (cow_meta_.segment_mapper_ != nullptr)
+        {
+            PageMapper *seg_mapper = cow_meta_.segment_mapper_.get();
+            const auto &seg_tbl = seg_mapper->GetMapping()->mapping_tbl_;
+            for (PageId seg_id = 0; seg_id < seg_tbl.size(); ++seg_id)
+            {
+                auto val_type =
+                    MappingSnapshot::GetValType(seg_tbl.Get(seg_id));
+                if (val_type == MappingSnapshot::ValType::Invalid ||
+                    val_type == MappingSnapshot::ValType::PageId)
+                {
+                    continue;
+                }
+                seg_mapper->FreePage(seg_id);
+            }
+        }
+
         cow_meta_.root_id_ = MaxPageId;
         cow_meta_.ttl_root_id_ = MaxPageId;
         cow_meta_.next_expire_ts_ = 0;

--- a/tests/large_value_gc.cpp
+++ b/tests/large_value_gc.cpp
@@ -250,6 +250,23 @@ void WaitForGc(int ms = 800)
     std::this_thread::sleep_for(chrono::milliseconds(ms));
 }
 
+template <typename Pred>
+bool WaitForCondition(chrono::milliseconds timeout,
+                      chrono::milliseconds step,
+                      Pred &&pred)
+{
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        if (pred())
+        {
+            return true;
+        }
+        std::this_thread::sleep_for(step);
+    }
+    return pred();
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -308,6 +325,53 @@ TEST_CASE(
 
     SegmentFileInfo after = InspectSegmentFiles(opts, tbl);
     REQUIRE_FALSE(after.any);
+
+    store->Stop();
+    CleanupStore(opts);
+}
+
+// Full-partition Truncate must also retire the large-value segment files. Its
+// fast path used to free only the data mapper, leaving the segment mapping
+// populated so GC kept every segment file forever.
+TEST_CASE("full truncate of a large-value partition retires every segment file",
+          "[large-value-gc][pinned]")
+{
+    PinnedHarness h;
+    eloqstore::KvOptions opts =
+        MakePinnedOpts(h, /*file_amp=*/2, /*seg_amp=*/2);
+    eloqstore::EloqStore *store = InitStore(opts);
+
+    eloqstore::TableIdent tbl{"lvgc_truncate_all", 0};
+    const size_t seg = h.SegmentSize();
+
+    {
+        std::vector<PinnedBatchEntry> entries;
+        entries.push_back(
+            {"k_a", h.AllocateSegmentAligned(seg * 2), 0x2010, "meta-a"});
+        entries.push_back(
+            {"k_b", h.AllocateSegmentAligned(seg * 3), 0x2020, "meta-b"});
+        entries.push_back(
+            {"k_c", h.AllocateSegmentAligned(seg * 1), 0x2030, "meta-c"});
+        WritePinnedBatch(store, tbl, std::move(entries), /*ts=*/1);
+    }
+
+    SegmentFileInfo before = InspectSegmentFiles(opts, tbl);
+    REQUIRE(before.any);
+
+    {
+        eloqstore::TruncateRequest req;
+        req.SetArgs(tbl, std::string{});  // empty position -> full truncate
+        store->ExecSync(&req);
+        REQUIRE(req.Error() == eloqstore::KvError::NoError);
+    }
+
+    // Nudge so UpdateMeta/GC runs on the now-empty segment mapping, then poll
+    // until GC has retired the segment files.
+    WriteSmall(store, tbl, "nudge", "x", /*ts=*/2);
+    REQUIRE(WaitForCondition(chrono::seconds(10),
+                             chrono::milliseconds(20),
+                             [&]
+                             { return !InspectSegmentFiles(opts, tbl).any; }));
 
     store->Stop();
     CleanupStore(opts);


### PR DESCRIPTION
## Problem

`Truncate`'s full-partition fast path (empty position) iterated only the **data** mapper and `FreePage`'d its pages — it never touched the **segment** mapper. For a partition holding large values the segment mapping stayed fully populated, so the empty snapshot flushed by `UpdateMeta` serialized it verbatim:

- GC's manifest replay kept every segment file alive **forever** (only `DropTable` would reclaim them);
- segment compaction counted them as live, so amplification never triggered;
- the stale segment mapping was copied into every later archive/branch snapshot.

Reads correctly saw an empty partition, so this is a silent space leak (disk **and** cloud) + snapshot pollution, not a correctness bug. The partial-truncate path already frees these via `DelLargeValue`.

## Fix

Free the segment pages too, mirroring the data-mapper loop, so the flushed segment mapping is empty and GC reclaims the files. The empty-snapshot flush serializes the current segment mapping (not deltas), so no delta recording is needed.

## Test

`large_value_gc`: full-truncating a partition of pinned large values leaves **no** segment files after GC. Verified it fails without the fix (the files are retained).