### PR TITLE
docs: drop stale ci-approved label requirement from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,4 +77,4 @@ Full subsystem documentation lives in `docs/architecture/` (see above). The load
 
 ## CI notes
 
-PRs need the `ci-approved` label for CI to run (`.github/workflows/ci.yml`). CI builds Debug with `SKIP_CREATE_BUCKET=ON`, runs C++ tests against MinIO, then builds/tests the Python wheel and Rust SDK.
+CI (`.github/workflows/ci.yml`) builds Debug with `SKIP_CREATE_BUCKET=ON`, runs C++ tests against MinIO, then builds/tests the Python wheel and Rust SDK.


### PR DESCRIPTION
The `ci-approved` label is no longer used to gate CI, but CLAUDE.md still told contributors PRs need it. Remove that stale sentence; keep the description of what CI actually does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI documentation to clarify the current build and test workflow.
  * Removed the outdated requirement for a specific pull request label to run CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->