### PR TITLE
fix: reject Floor in pinned mode instead of leaking GC-pool segments

### DIFF
--- a/src/storage/shard.cpp
+++ b/src/storage/shard.cpp
@@ -641,6 +641,13 @@ bool Shard::ProcessReq(KvRequest *req)
         auto lbd = [task, req]() -> KvError
         {
             auto floor_req = static_cast<FloorRequest *>(req);
+            // Floor's large_value_ is an IoStringBuffer; in pinned mode its
+            // fragments come from the unrecyclable shard-private GC pool, same
+            // as the Read IoStringBuffer arm rejected above.
+            if (!shard->store_->Options().pinned_memory_chunks.empty())
+            {
+                return KvError::InvalidArgs;
+            }
             KvError err = task->Floor(req->TableId(),
                                       floor_req->Key(),
                                       floor_req->floor_key_,

--- a/tests/large_value_e2e.cpp
+++ b/tests/large_value_e2e.cpp
@@ -714,6 +714,28 @@ TEST_CASE("EloqStore pinned write + read round-trips with metadata",
     CleanupStore(opts);
 }
 
+// Floor has only an IoStringBuffer destination, which draws from the
+// unrecyclable shard-private GC pool in pinned mode, so it is rejected.
+TEST_CASE("EloqStore rejects Floor in pinned mode", "[large-value-e2e][pinned]")
+{
+    PinnedHarness harness;
+    auto opts = MakePinnedOpts(harness);
+    auto *store = InitStore(opts);
+
+    eloqstore::TableIdent tbl{"pinned-floor", 0};
+    const size_t value_size = harness.SegmentSize() * 3;
+    auto write_buf = harness.AllocateSegmentAligned(value_size);
+    WritePinned(store, harness, tbl, "k", write_buf, 0xf0u);
+
+    eloqstore::FloorRequest r;
+    r.SetArgs(tbl, "k");
+    store->ExecSync(&r);
+    REQUIRE(r.Error() == eloqstore::KvError::InvalidArgs);
+
+    store->Stop();
+    CleanupStore(opts);
+}
+
 TEST_CASE("EloqStore mixed metadata / no-metadata large values via overload A",
           "[large-value-e2e][pinned]")
 {


### PR DESCRIPTION
## Problem

A `FloorRequest` resolves a large-value floor entry into its own `IoStringBuffer` (`floor_req->large_value_`). In KV Cache **pinned mode**, `GetGlobalRegisteredMemory()` returns the shard-private GC pool, whose segments no public API can `Recycle`. So every `Floor` that lands on a large-value entry permanently drains `num_segments` from that pool. Once it empties, background segment compaction spins on `YieldToLowPQ` forever (space reclamation halts) and later large-value Floors hang.

`Read` already rejects its `IoStringBuffer` overload in pinned mode for exactly this reason (pinned callers must use the pinned-destination overloads). `Floor` has no pinned-destination variant, and its dispatch was missing the equivalent guard.

## Fix

Reject `FloorRequest` in pinned mode (`pinned_memory_chunks` non-empty) with `InvalidArgs`, mirroring the `Read` guard.

## Test

`large_value_e2e` [pinned]: a `Floor` against a pinned-mode store now returns `InvalidArgs`; without the guard it returns `NoError` (leaking the segments). Full suite passes (448 assertions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid `Floor` requests involving large values in pinned-memory mode are now rejected with a clear `InvalidArgs` error instead of being processed unsuccessfully.

* **Tests**
  * Added coverage verifying that pinned large-value `Floor` requests are rejected as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->