### PR TITLE
fix: skip SetDone() for internal requests to fix UAF

### DIFF
--- a/src/storage/shard.cpp
+++ b/src/storage/shard.cpp
@@ -1147,11 +1147,19 @@ void Shard::OnTaskFinished(KvTask *task)
             // external waiter or callback, so drop done_req when it points at
             // one of them to avoid SetDone()-ing a freed request afterwards
             // (mirrors the embedded internal reopen-driver handling above).
-            if (done_req == &pending_q.compact_req_ ||
-                done_req == &pending_q.local_gc_req_ ||
-                done_req == &pending_q.expire_req_)
+            bool is_embedded = (req == &pending_q.compact_req_ ||
+                                req == &pending_q.local_gc_req_ ||
+                                req == &pending_q.expire_req_);
+            if (is_embedded)
             {
                 done_req = nullptr;
+            }
+            // Do not erase the queue if an embedded request is being retried
+            // (e.g. OOM), as erasing it would destroy the request object.
+            if (!is_embedded || request_completed)
+            {
+                // No more write requests, remove the pending queue.
+                pending_queues_.erase(pending_it);
             }
             // No more write requests, remove the pending queue.
             pending_queues_.erase(pending_it);

--- a/src/storage/shard.cpp
+++ b/src/storage/shard.cpp
@@ -1161,8 +1161,6 @@ void Shard::OnTaskFinished(KvTask *task)
                 // No more write requests, remove the pending queue.
                 pending_queues_.erase(pending_it);
             }
-            // No more write requests, remove the pending queue.
-            pending_queues_.erase(pending_it);
         }
         dispatch_pending_writes = true;
     }

--- a/src/storage/shard.cpp
+++ b/src/storage/shard.cpp
@@ -1142,6 +1142,17 @@ void Shard::OnTaskFinished(KvTask *task)
         pending_q.running_ = false;
         if (pending_q.Empty())
         {
+            // The internal compact / local-gc / clean-expired requests are
+            // embedded in this queue; erasing it destroys them. They have no
+            // external waiter or callback, so drop done_req when it points at
+            // one of them to avoid SetDone()-ing a freed request afterwards
+            // (mirrors the embedded internal reopen-driver handling above).
+            if (done_req == &pending_q.compact_req_ ||
+                done_req == &pending_q.local_gc_req_ ||
+                done_req == &pending_q.expire_req_)
+            {
+                done_req = nullptr;
+            }
             // No more write requests, remove the pending queue.
             pending_queues_.erase(pending_it);
         }


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [ ] Reference the link of RFC if exists
- [ ] Pass `ctest --test-dir build/tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented potential errors when internal storage operations complete and their pending queues are cleared.
  * Improved stability during write, compaction, garbage collection, and expiration processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->