### PR TITLE
fix: identify EloqStore module with updated brpc

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -50,7 +50,7 @@ FetchContent_Declare(glog
 # seeds its glog/liburing discovery variables before making it available.
 FetchContent_Declare(brpc
         GIT_REPOSITORY https://github.com/eloqdata/brpc.git
-        GIT_TAG 02c3f2de6a79b3d4828a3f75b04096f06be929c5
+        GIT_TAG 6d56abecbb9ce6c6b862a1bb6389f5bd920b34aa
         GIT_PROGRESS TRUE)
 
 # Catch2 (tests only)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -50,7 +50,7 @@ FetchContent_Declare(glog
 # seeds its glog/liburing discovery variables before making it available.
 FetchContent_Declare(brpc
         GIT_REPOSITORY https://github.com/eloqdata/brpc.git
-        GIT_TAG 6d56abecbb9ce6c6b862a1bb6389f5bd920b34aa
+        GIT_TAG 34e0e01d5a528bc9fc91a8abe32b701313791a4b
         GIT_PROGRESS TRUE)
 
 # Catch2 (tests only)

--- a/include/eloqstore_module.h
+++ b/include/eloqstore_module.h
@@ -19,6 +19,11 @@ public:
     }
     ~EloqStoreModule() = default;
 
+    eloq::ModuleType Type() const override
+    {
+        return eloq::ModuleType::kEloqStore;
+    }
+
     void ExtThdStart(int thd_id) override;
     void ExtThdEnd(int thd_id) override;
     void Process(int thd_id) override;


### PR DESCRIPTION
## Context

[eloqdata/brpc#29](https://github.com/eloqdata/brpc/pull/29) adds stable module identities and makes `EloqModule::Type()` mandatory. Data Substrate's EloqStore build therefore fails because `EloqStoreModule` remains abstract. The brpc PR has been merged as `34e0e01d5a528bc9fc91a8abe32b701313791a4b`.

## Behavior before and after

Before, module-mode builds against the updated brpc fail while constructing `EloqStoreModule`.

After, EloqStore reports the stable `kEloqStore` module identity expected by brpc and module-mode builds succeed.

## Implementation

- Implement `EloqStoreModule::Type()` as `ModuleType::kEloqStore`.
- Pin the standalone EloqStore brpc dependency to the merged eloqdata/brpc#29 commit (`34e0e01d`).

## Test plan

- [ ] Add tests for the change
- [ ] Document changes
- [ ] Reference the link of issue using `fixes eloqdb/eloqstore#issue_id`
- [x] Reference the brpc dependency PR
- [ ] Pass `ctest --test-dir build/tests/`

Commands and results:

```text
clang-format-18 -i include/eloqstore_module.h
  passed with Ubuntu clang-format 18.1.3

git diff --check
  passed

cmake -S . -B bld-ci-maxclients \
  -DWITH_TESTS=ON \
  -DWITH_DATA_STORE=ELOQDSS_ELOQSTORE \
  -DWITH_LOG_STATE=ROCKSDB \
  -DCMAKE_BUILD_TYPE=Debug \
  -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
  -DELOQ_THIRD_PARTY_REQUIRED=ON
  passed

cmake --build bld-ci-maxclients --target eloqstore --parallel 4
  passed: [100%] Built target eloqstore

git rev-parse 6d56abec^{tree} 34e0e01d^{tree}
  both resolve to 48c080e601752e61d4919cf1296394f53498abbf
```

`bash scripts/format.sh` was attempted but its ARM64 bootstrap could not download the hard-coded `libtinfo5_6.3-2ubuntu0.1_arm64.deb`; no files were changed by that failed attempt. Before replacing the temporary brpc head with its tree-identical merge commit, EloqStore CI passed format, cpplint, CLA, CodeRabbit, and the full amd64/arm64 test jobs. The new dependency-pin-only commit has triggered replacement CI.

## Risk and rollback

The source change only affects `ELOQ_MODULE_ENABLED` builds. The dependency now points to a commit reachable from brpc `master`. Roll back by reverting this PR and restoring the previous brpc pin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved module identification so the EloqStore component is recognized consistently by the platform.

- **Maintenance**
  - Updated the embedded brpc dependency to a newer revision, incorporating dependency-level improvements and fixes.

- **Compatibility**
  - Preserved existing public behavior while improving integration with the surrounding system and maintaining compatibility with current workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->